### PR TITLE
Fix ship attack value

### DIFF
--- a/OpenSolarMax.Levels.S2/Levels/08.json
+++ b/OpenSolarMax.Levels.S2/Levels/08.json
@@ -3,7 +3,7 @@
         "planet30": { "$base": "planet", "radius": 19.2, "volume": 300, "population": 30, "produceSpeed": 0.6 },
         "planet40": { "$base": "planet", "radius": 25.6, "volume": 400, "population": 40, "produceSpeed": 0.8 },
         "planet50": { "$base": "planet", "radius": 32.0, "volume": 500, "population": 50, "produceSpeed": 1.0 },
-        "blue": { "$base": "party", "color": "#5FB6FF", "workload": 1, "attack": 1, "health": 1 }
+        "blue": { "$base": "party", "color": "#5FB6FF", "workload": 1, "attack": 0.1, "health": 1 }
     },
 
     "entities": [

--- a/OpenSolarMax.Levels.S2/Levels/18.json
+++ b/OpenSolarMax.Levels.S2/Levels/18.json
@@ -3,7 +3,7 @@
         "planet30": { "$base": "planet", "radius": 19.2, "volume": 300, "population": 30, "produceSpeed": 0.6 },
         "planet40": { "$base": "planet", "radius": 25.6, "volume": 400, "population": 40, "produceSpeed": 0.8 },
         "planet50": { "$base": "planet", "radius": 32.0, "volume": 500, "population": 50, "produceSpeed": 1.0 },
-        "blue": { "$base": "party", "color": "#5FB6FF", "workload": 1, "attack": 1, "health": 1 }
+        "blue": { "$base": "party", "color": "#5FB6FF", "workload": 1, "attack": 0.1, "health": 1 }
     },
 
     "entities": [


### PR DESCRIPTION
In the original SolarMax2, combat is calculated by summing all ships’ attack, multiplying the result by 10, dividing by a defense coefficient (default 1), and applying it to a health value of 100. Effectively, each ship’s attack equals 1/10 of its health. Accordingly, in OpenSolarMax2, the attack value should be set to 0.1.

---

SolarMax2 原版游戏中的战斗逻辑是：所有舰船的战斗力总和，还要乘上 10 作为系数，然后除以默认值为 1 的防御系数，再作用到默认值为 100 的生命值上。因此总的算下来，实际上每艘船的战斗力为其生命值的 1/10。因此在 OpenSolarMax2 的系统中，应当将攻击力修正为 0.1。