### PR TITLE
Sort the combat arcs according to the parties entity IDs

### DIFF
--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
@@ -87,7 +87,7 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
         if (registry.Ships.Count == 0)
             return;
 
-        var parties = registry.Ships.Select((g) => g.Key).ToArray();
+        var parties = registry.Ships.Select(g => g.Key).Order().ToArray();
 
         if (parties.Length == 1)
         {
@@ -127,7 +127,8 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
             var ringCenter = new Vector2(planetInCanvas.X, planetInCanvas.Y);
 
             // 获得各阵营的单位数目、颜色和标签
-            var weights = registry.Ships.Select((g) => g.Count()).ToArray();
+            var shipsRegistry = registry.Ships;
+            var weights = parties.Select(p => shipsRegistry[p].Count()).ToArray();
             var colors = parties.Select((p) => p.Get<PartyReferenceColor>().Value).ToArray();
             var labels = weights.Select((w) => string.Format(_textFormat, w)).ToArray();
 


### PR DESCRIPTION
Previously, the ordering of `weights` depended entirely on the order of `Group` entries in `Lookup` and was nondeterministic. It is now sorted by the entity IDs of party entities, fixing the order of the combat arcs.

---

之前 `weights` 的顺序完全取决于 `Lookup` 中 `Group` 的顺序，是不确定的。现按照阵营实体的实体 ID 来排序，将战斗预览环的顺序固定下来。