### PR TITLE
Add gaps between combat arcs

### DIFF
--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
@@ -29,6 +29,7 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
     private const float _ringRadiusFactor = 1.8f;
     private const float _ringThickness = 3;
     private const float _labelRadiusFactor = 1.25f;
+    private const float _arcGapAngle = 3 * MathF.PI / 180;
 
     private static readonly QueryDescription _planetDesc =
         new QueryDescription().WithAll<AnchoredShipsRegistry, ReferenceSize, AbsoluteTransform>();
@@ -54,10 +55,11 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
         // 计算总权重
         float weightsSum = weights.Sum();
 
+        // 除去 gap
+        var total = 2 * MathF.PI - _arcGapAngle * weights.Length;
+
         // 计算每个实例应当占有的弧度
-        var alphas = new float[weights.Length];
-        for (int i = 0; i < weights.Length; i++)
-            alphas[i] = (2 * MathF.PI * weights[i] / weightsSum);
+        var alphas = weights.Select(w => w / weightsSum * total + _arcGapAngle).ToArray();
 
         // 计算每个实例在无偏移情况下的中心线极角
         var thetas = new float[weights.Length];
@@ -138,9 +140,10 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
             // 绘制各个阵营对应的弧
             for (int i = 0; i < parties.Length; i++)
             {
-                var radians = arcs[i + 1] - arcs[i];
+                var radians = arcs[i + 1] - arcs[i] - _arcGapAngle;
 
-                _ringRenderer.DrawArc(ringCenter, ringRadius, arcs[i], radians, colors[i], _ringThickness);
+                _ringRenderer.DrawArc(ringCenter, ringRadius, arcs[i] + _arcGapAngle / 2, radians,
+                                      colors[i], _ringThickness);
             }
 
             // 绘制各个阵营的单位数目文字


### PR DESCRIPTION
Fixed gaps have been added between the arcs on the combat ring. In cases where an arc is very small, potentially smaller than one gap, the total gap degrees are first subtracted, and then the remaining arc is distributed among the factions.

---

为战斗预览环的各个阵营之间添加了固定弧度的空隙。由于要考虑到阵营舰船数占比真的很小的情况，原来的战斗弧可能还不足一个空隙大，故事先减去了所有空隙的弧度，再由各个阵营分配余下的弧度。

<img width="360" height="320" alt="image" src="https://github.com/user-attachments/assets/32b1d54e-273b-4a60-9c39-4c041be14d06" />