### PR TITLE
Standardize transform usage

### DIFF
--- a/OpenSolarMax.Mods.Core/Components/InfiniteZBarrier.cs
+++ b/OpenSolarMax.Mods.Core/Components/InfiniteZBarrier.cs
@@ -2,10 +2,10 @@ using Microsoft.Xna.Framework;
 
 namespace OpenSolarMax.Mods.Core.Components;
 
-public struct Barrier
+public struct InfiniteZBarrier
 {
     /// <summary>
     /// 障碍线段的起点和终点
     /// </summary>
-    public Vector3 Head, Tail;
+    public Vector2 Head, Tail;
 }

--- a/OpenSolarMax.Mods.Core/Concepts/DestinationSurroundFlare.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/DestinationSurroundFlare.cs
@@ -6,6 +6,7 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -87,7 +88,7 @@ public class DestinationSurroundFlareApplier(IAssetsManager assets, IConceptFact
                 Transform = new RelativeTransformOptions
                 {
                     Parent = desc.Effect,
-                    Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, desc.Angle)
+                    Rotation = TransformProjection.To3D(desc.Angle)
                 }
             });
         var transform = factory.Make(

--- a/OpenSolarMax.Mods.Core/Concepts/InfiniteZBarrier.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/InfiniteZBarrier.cs
@@ -7,36 +7,35 @@ using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Mods.Core.Components;
-using Barrier = OpenSolarMax.Mods.Core.Components.Barrier;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
 public static partial class ConceptNames
 {
-    public const string Barrier = "Barrier";
+    public const string InfiniteZBarrier = "InfiniteZBarrier";
 }
 
-[Define(ConceptNames.Barrier)]
-public abstract class BarrierDefinition : IDefinition
+[Define(ConceptNames.InfiniteZBarrier)]
+public abstract class InfiniteZBarrierDefinition : IDefinition
 {
     public static Signature Signature { get; } = new(
-        typeof(Barrier),
+        typeof(InfiniteZBarrier),
         typeof(BarrierMembers)
     );
 }
 
-[Describe(ConceptNames.Barrier)]
-public class BarrierDescription : IDescription
+[Describe(ConceptNames.InfiniteZBarrier)]
+public class InfiniteZBarrierDescription : IDescription
 {
-    public required Vector3 Head { get; set; }
+    public required Vector2 Head { get; set; }
 
-    public required Vector3 Tail { get; set; }
+    public required Vector2 Tail { get; set; }
 }
 
-[Apply(ConceptNames.Barrier)]
-public class BarrierApplier(
+[Apply(ConceptNames.InfiniteZBarrier)]
+public class InfiniteZBarrierApplier(
     IAssetsManager assets, IConceptFactory factory, [Section("applier:barrier")] IConfiguration configs)
-    : IApplier<BarrierDescription>
+    : IApplier<InfiniteZBarrierDescription>
 {
     private readonly Vector2 _barrierNodeTextureSize =
         new(configs.RequireValue<float>("node:size:x"), configs.RequireValue<float>("node:size:y"));
@@ -53,29 +52,29 @@ public class BarrierApplier(
 
     private readonly TextureRegion _barrierEdgeTexture = assets.Load<TextureRegion>("/Textures/BarrierLine.json:Line");
 
-    public void Apply(CommandBuffer commandBuffer, Entity entity, BarrierDescription desc)
+    public void Apply(CommandBuffer commandBuffer, Entity entity, InfiniteZBarrierDescription desc)
     {
-        commandBuffer.Set(in entity, new Barrier() { Head = desc.Head, Tail = desc.Tail });
+        commandBuffer.Set(in entity, new InfiniteZBarrier() { Head = desc.Head, Tail = desc.Tail });
 
         // 创建两头的节点实体
         var node1 = factory.Make(World.Worlds[entity.WorldId], commandBuffer, new DrawableDescription()
         {
-            Transform = new AbsoluteTransformOptions() { Translation = desc.Head with { Z = 10 } },
+            Transform = new AbsoluteTransformOptions() { Translation = new Vector3(desc.Head, 0) },
             Texture = _barrierNodeTexture,
             Size = _barrierNodeTextureSize,
         });
         var node2 = factory.Make(World.Worlds[entity.WorldId], commandBuffer, new DrawableDescription()
         {
-            Transform = new AbsoluteTransformOptions() { Translation = desc.Tail with { Z = 10 } },
+            Transform = new AbsoluteTransformOptions() { Translation = new Vector3(desc.Tail, 0) },
             Texture = _barrierNodeTexture,
             Size = _barrierNodeTextureSize,
         });
 
         // 创建边实体
         var vector = desc.Tail - desc.Head;
-        var dir = Vector3.Normalize(vector);
+        var dir = Vector2.Normalize(vector);
         var edgeRot = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.Atan2(vector.Y, vector.X));
-        var dist = (vector with { Z = 0 }).Length();
+        var dist = vector.Length();
         var edgeParts = new List<Entity>();
         for (var d = _barrierEdgeSpace; d < dist; d += _barrierEdgeSpace)
         {
@@ -83,7 +82,7 @@ public class BarrierApplier(
             {
                 Transform = new AbsoluteTransformOptions()
                 {
-                    Translation = desc.Head + d * dir,
+                    Translation = new Vector3(desc.Head + d * dir, 0),
                     Rotation = edgeRot,
                 },
                 Texture = _barrierEdgeTexture,

--- a/OpenSolarMax.Mods.Core/Concepts/InfiniteZBarrier.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/InfiniteZBarrier.cs
@@ -7,6 +7,7 @@ using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -59,13 +60,13 @@ public class InfiniteZBarrierApplier(
         // 创建两头的节点实体
         var node1 = factory.Make(World.Worlds[entity.WorldId], commandBuffer, new DrawableDescription()
         {
-            Transform = new AbsoluteTransformOptions() { Translation = new Vector3(desc.Head, 0) },
+            Transform = new AbsoluteTransformOptions() { Translation = TransformProjection.To3D(desc.Head) },
             Texture = _barrierNodeTexture,
             Size = _barrierNodeTextureSize,
         });
         var node2 = factory.Make(World.Worlds[entity.WorldId], commandBuffer, new DrawableDescription()
         {
-            Transform = new AbsoluteTransformOptions() { Translation = new Vector3(desc.Tail, 0) },
+            Transform = new AbsoluteTransformOptions() { Translation = TransformProjection.To3D(desc.Tail) },
             Texture = _barrierNodeTexture,
             Size = _barrierNodeTextureSize,
         });
@@ -73,7 +74,7 @@ public class InfiniteZBarrierApplier(
         // 创建边实体
         var vector = desc.Tail - desc.Head;
         var dir = Vector2.Normalize(vector);
-        var edgeRot = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.Atan2(vector.Y, vector.X));
+        var edgeRot = TransformProjection.To3D(MathF.Atan2(vector.Y, vector.X));
         var dist = vector.Length();
         var edgeParts = new List<Entity>();
         for (var d = _barrierEdgeSpace; d < dist; d += _barrierEdgeSpace)
@@ -82,7 +83,7 @@ public class InfiniteZBarrierApplier(
             {
                 Transform = new AbsoluteTransformOptions()
                 {
-                    Translation = new Vector3(desc.Head + d * dir, 0),
+                    Translation = TransformProjection.To3D(desc.Head + d * dir),
                     Rotation = edgeRot,
                 },
                 Texture = _barrierEdgeTexture,
@@ -92,8 +93,6 @@ public class InfiniteZBarrierApplier(
             });
             edgeParts.Add(edgePart);
         }
-
-        // TODO: 处理 2D 和 3D 之间的映射
 
         commandBuffer.Set(in entity, new BarrierMembers(node1, node2, edgeParts.ToArray()));
     }

--- a/OpenSolarMax.Mods.Core/Concepts/LaserBeam.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/LaserBeam.cs
@@ -7,6 +7,7 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Utils;
 using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
@@ -59,17 +60,13 @@ public class LaserBeamApplier(IAssetsManager assets, IConceptFactory factory) : 
         // 摆放位置
         ref readonly var turretPose = ref desc.Planet.Get<AbsoluteTransform>();
         var vector = desc.TargetPosition - turretPose.Translation;
-        var unitX = Vector3.Normalize(vector);
-        var unitY = Vector3.Normalize(new(-vector.Y, vector.X, 0));
-        var unitZ = Vector3.Cross(unitX, unitY);
-        var rotation = new Matrix { Right = unitX, Up = unitY, Backward = unitZ };
         factory.Make(world, commandBuffer, ConceptNames.RelativeTransform,
                      new RelativeTransformDescription
                      {
                          Parent = desc.Planet,
                          Child = entity,
                          Translation = Vector3.Zero,
-                         Rotation = Quaternion.CreateFromRotationMatrix(rotation)
+                         Rotation = TransformProjection.UprightAim(vector)
                      });
 
         // 设置纹理

--- a/OpenSolarMax.Mods.Core/Concepts/LaserFlash.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/LaserFlash.cs
@@ -7,7 +7,6 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
-using Vector3 = System.Numerics.Vector3;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 

--- a/OpenSolarMax.Mods.Core/Concepts/Party.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Party.cs
@@ -77,7 +77,7 @@ public class PartyApplier : IApplier<PartyDescription>
 
         commandBuffer.Set(in entity, new ColonizationAbility { ProgressPerSecond = 1 });
 
-        commandBuffer.Set(in entity, new Ai { Enabled = true });
+        commandBuffer.Set(in entity, new Ai { Enabled = false });
         commandBuffer.Set(in entity, new AiCooldown { Duration = TimeSpan.FromSeconds(3) });
         commandBuffer.Set(in entity, new AiTimer { TimeLeft = TimeSpan.FromSeconds(2) });
     }

--- a/OpenSolarMax.Mods.Core/Concepts/PortalChargingSurroundFlare.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/PortalChargingSurroundFlare.cs
@@ -6,6 +6,7 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -95,7 +96,7 @@ public class PortalChargingSurroundFlareApplier(IAssetsManager assets, IConceptF
                                          Transform = new RelativeTransformOptions
                                          {
                                              Parent = desc.Effect,
-                                             Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, desc.Angle)
+                                             Rotation = TransformProjection.To3D(desc.Angle)
                                          }
                                      });
         var transform = factory.Make(world, commandBuffer, ConceptNames.RelativeTransform,

--- a/OpenSolarMax.Mods.Core/Concepts/TransportationTrail.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/TransportationTrail.cs
@@ -6,6 +6,7 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -68,14 +69,10 @@ public class TransportationTrailApplier(IAssetsManager assets) : IApplier<Transp
         });
 
         // 放置位置
-        var unitX = Vector3.Normalize(vector);
-        var unitY = Vector3.Normalize(new(-vector.Y, vector.X, 0));
-        var unitZ = Vector3.Cross(unitX, unitY);
-        var rotation = new Matrix { Right = unitX, Up = unitY, Backward = unitZ };
         commandBuffer.Set(in entity, new AbsoluteTransform
         {
             Translation = desc.Tail,
-            Rotation = Quaternion.CreateFromRotationMatrix(rotation)
+            Rotation = TransformProjection.UprightAim(vector)
         });
 
         // 播放动画

--- a/OpenSolarMax.Mods.Core/Declarations/BarrierDeclaration.cs
+++ b/OpenSolarMax.Mods.Core/Declarations/BarrierDeclaration.cs
@@ -5,8 +5,8 @@ using OpenSolarMax.Mods.Core.Concepts;
 
 namespace OpenSolarMax.Mods.Core.Declarations;
 
-[Declare(ConceptNames.Barrier), SchemaName("barrier")]
-public class BarrierDeclaration : IDeclaration<BarrierDescription, BarrierDeclaration>
+[Declare(ConceptNames.InfiniteZBarrier), SchemaName("barrier")]
+public class BarrierDeclaration : IDeclaration<InfiniteZBarrierDescription, BarrierDeclaration>
 {
     public Vector2? Head { get; set; }
 
@@ -21,14 +21,14 @@ public class BarrierDeclaration : IDeclaration<BarrierDescription, BarrierDeclar
         };
     }
 
-    public BarrierDescription ToDescription(IReadOnlyDictionary<string, Entity> otherEntities)
+    public InfiniteZBarrierDescription ToDescription(IReadOnlyDictionary<string, Entity> otherEntities)
     {
         if (Head is null || Tail is null) throw new NullReferenceException();
 
-        var desc = new BarrierDescription()
+        var desc = new InfiniteZBarrierDescription()
         {
-            Head = new Vector3(Head.Value, 0),
-            Tail = new Vector3(Tail.Value, 0)
+            Head = Head.Value,
+            Tail = Tail.Value
         };
 
         return desc;

--- a/OpenSolarMax.Mods.Core/Declarations/PredefinedOrbitDeclaration.cs
+++ b/OpenSolarMax.Mods.Core/Declarations/PredefinedOrbitDeclaration.cs
@@ -2,6 +2,7 @@ using Arch.Core;
 using Microsoft.Xna.Framework;
 using OpenSolarMax.Game.Modding.Declaration;
 using OpenSolarMax.Mods.Core.Concepts;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Declarations;
 
@@ -50,7 +51,7 @@ public class PredefinedOrbitDeclaration : IDeclaration<PredefinedOrbitDescriptio
         desc.Transform = tfDesc.Transform;
 
         if (Roll is not null)
-            desc.Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, Roll.Value);
+            desc.Rotation = TransformProjection.To3D(Roll.Value);
 
         return desc;
     }

--- a/OpenSolarMax.Mods.Core/Declarations/TransformableDeclaration.cs
+++ b/OpenSolarMax.Mods.Core/Declarations/TransformableDeclaration.cs
@@ -2,6 +2,7 @@ using Arch.Core;
 using Microsoft.Xna.Framework;
 using OpenSolarMax.Game.Modding.Declaration;
 using OpenSolarMax.Mods.Core.Concepts;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Declarations;
 
@@ -32,14 +33,14 @@ public class TransformableDeclaration : IDeclaration<TransformableDescription, T
         {
             var transform = new AbsoluteTransformOptions();
             if (Position is { } position)
-                transform.Translation = new Vector3(position.X, position.Y, 0);
+                transform.Translation = TransformProjection.To3D(position);
             return new TransformableDescription() { Transform = transform };
         }
         else if (Orbit is null)
         {
             var transform = new RelativeTransformOptions() { Parent = otherEntities[Parent] };
             if (Position is { } position)
-                transform.Translation = new Vector3(position.X, position.Y, 0);
+                transform.Translation = TransformProjection.To3D(position);
             return new TransformableDescription() { Transform = transform };
         }
         else

--- a/OpenSolarMax.Mods.Core/Systems/Render/SoundEffect/UpdateListener3DAttributesSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/SoundEffect/UpdateListener3DAttributesSystem.cs
@@ -29,8 +29,8 @@ public sealed partial class UpdateListener3DAttributesSystem(World world) : ICal
             forward = { x = 0, y = 0, z = 1 },
             position =
             {
-                x = transform.TransformToRoot.Translation.X,
-                y = transform.TransformToRoot.Translation.Y,
+                x = transform.Translation.X,
+                y = transform.Translation.Y,
                 z = camera.Width / 2 / 1.7320508f,
             },
             up = { x = 0, y = 1, z = 0 },

--- a/OpenSolarMax.Mods.Core/Systems/Render/SoundEffect/UpdateSoundEffect3DAttributesSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/SoundEffect/UpdateSoundEffect3DAttributesSystem.cs
@@ -24,9 +24,9 @@ public sealed partial class UpdateSoundEffect3DAttributesSystem(World world) : I
             forward = { x = 0, y = 0, z = 1 },
             position =
             {
-                x = transform.TransformToRoot.Translation.X,
-                y = transform.TransformToRoot.Translation.Y,
-                z = transform.TransformToRoot.Translation.Z
+                x = transform.Translation.X,
+                y = transform.Translation.Y,
+                z = transform.Translation.Z
             },
             up = { x = 0, y = 1, z = 0 },
             velocity = { x = 0, y = 0, z = 0 },

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/DrawShapesSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/DrawShapesSystem.cs
@@ -9,6 +9,7 @@ using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Game.Modding.UI;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -47,8 +48,8 @@ public sealed partial class DrawShapesSystem(World world, GraphicsDevice graphic
                             * absoluteTransform.TransformToRoot;
 
         // 将变换投影到二维平面
-        var rotatedUnitX = Vector3.Transform(Vector3.UnitX, absoluteTransform.Rotation);
-        anchorToWorld = Matrix.CreateRotationZ(MathF.Atan2(rotatedUnitX.Y, rotatedUnitX.X))
+        var projectedRotation = TransformProjection.To2D(Quaternion.CreateFromRotationMatrix(anchorToWorld));
+        anchorToWorld = Matrix.CreateRotationZ(projectedRotation)
                         * Matrix.CreateTranslation(anchorToWorld.Translation);
 
         // 完成最后的缩放

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/DrawSpritesSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/DrawSpritesSystem.cs
@@ -8,6 +8,7 @@ using Nine.Assets;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -48,8 +49,8 @@ public sealed partial class DrawSpritesSystem(World world, GraphicsDevice graphi
         if (sprite.Billboard)
         {
             // 将变换投影到二维平面
-            var rotatedUnitX = Vector3.Transform(Vector3.UnitX, absoluteTransform.Rotation);
-            anchorToWorld = Matrix.CreateRotationZ(MathF.Atan2(rotatedUnitX.Y, rotatedUnitX.X))
+            var projectedRotation = TransformProjection.To2D(Quaternion.CreateFromRotationMatrix(anchorToWorld));
+            anchorToWorld = Matrix.CreateRotationZ(projectedRotation)
                             * Matrix.CreateTranslation(anchorToWorld.Translation);
         }
 

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeAnchoredUnitsSystem.cs
@@ -12,6 +12,7 @@ using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Game.Utils;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -107,8 +108,8 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
 
             // 计算文字位置
             var textSize = _font.MeasureString(text);
-            var planetInCanvas = Vector3.Transform(pose.Translation, worldToCanvas);
-            var position = new Vector2(planetInCanvas.X, planetInCanvas.Y)
+            var planetInCanvas = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToCanvas));
+            var position = planetInCanvas
                            + new Vector2(_labelXOffsetFactor, _labelYOffsetFactor) * refSize.Radius * scale
                            - textSize / 2;
             var shadowPosition = position with { Y = position.Y + _shadowDistance };
@@ -131,8 +132,7 @@ public sealed partial class VisualizeAnchoredUnitsSystem(
             var labelRadius = refSize.Radius * _labelRadiusFactor * scale;
 
             // 获得战斗环的圆心
-            var planetInCanvas = Vector3.Transform(pose.Translation, worldToCanvas);
-            var ringCenter = new Vector2(planetInCanvas.X, planetInCanvas.Y);
+            var ringCenter = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToCanvas));
 
             // 获得各阵营的单位数目、颜色和标签
             var shipsRegistry = registry.Ships;

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeColonizationSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeColonizationSystem.cs
@@ -7,9 +7,9 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
-using OpenSolarMax.Game.Utils;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -60,8 +60,7 @@ public sealed partial class VisualizeColonizationSystem(
         var ringRadius = refSize.Radius * _ringRadiusFactor * scale;
 
         // 获得殖民环的圆心
-        var planetInCanvas = Vector3.Transform(pose.Translation, worldToCanvas);
-        var ringCenter = new Vector2(planetInCanvas.X, planetInCanvas.Y);
+        var ringCenter = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToCanvas));
 
         // 计算首尾角度
         var angle = MathF.PI * 2 * colonizationState.Progress / colonizable.Volume;

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeEntityIdsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeEntityIdsSystem.cs
@@ -8,9 +8,9 @@ using Microsoft.Xna.Framework.Graphics;
 using Nine.Assets;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
-using OpenSolarMax.Game.Utils;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -42,8 +42,8 @@ public sealed partial class VisualizeEntityIdsSystem(
 
         // 计算文字位置
         var textSize = _font.MeasureString(text);
-        var entityInCanvas = Vector3.Transform(pose.Translation, worldToCanvas);
-        var position = new Vector2(entityInCanvas.X, entityInCanvas.Y) - textSize / 2;
+        var entityInCanvas = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToCanvas));
+        var position = entityInCanvas - textSize / 2;
 
         // 绘制文字
         _font.DrawText(_fontRenderer, text, position, _textColor, effect: FontSystemEffect.Stroked, effectAmount: 1);

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
@@ -9,7 +9,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
-using OpenSolarMax.Game.Utils;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Graphics;
 using OpenSolarMax.Mods.Core.Utils;
@@ -60,8 +59,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
         var ringRadius = refSize.Radius * _ringRadiusFactor * scale;
 
         // 计算选择环的位置
-        var poseInCanvas = Vector3.Transform(pose.Translation, worldToCanvas);
-        var ringInCanvas = new Vector2(poseInCanvas.X, poseInCanvas.Y);
+        var ringInCanvas = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToCanvas));
 
         // 绘制选择环
         _circleRenderer.DrawCircle(ringInCanvas, ringRadius, ringColor, ringThickness);
@@ -93,8 +91,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
         var targetCompos = target.Get<ReferenceSize, AbsoluteTransform>();
         ref readonly var targetRefSize = ref targetCompos.t0;
         ref readonly var targetPose = ref targetCompos.t1;
-        var targetInCanvas3D = Vector3.Transform(targetPose.Translation, worldToViewport);
-        var targetInCanvas = new Vector2(targetInCanvas3D.X, targetInCanvas3D.Y);
+        var targetInCanvas = TransformProjection.To2D(Vector3.Transform(targetPose.Translation, worldToViewport));
         var targetRingRadius = targetRefSize.Radius * _ringRadiusFactor * scale;
 
         foreach (var (source, color) in Enumerable.Zip(sources, colors))
@@ -104,8 +101,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
             ref readonly var pose = ref compos.t1;
 
             // 计算起点位置和半径
-            var sourceInCanvas3D = Vector3.Transform(pose.Translation, worldToViewport);
-            var sourceInCanvas = new Vector2(sourceInCanvas3D.X, sourceInCanvas3D.Y);
+            var sourceInCanvas = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToViewport));
             var sourceRingRadius = refSize.Radius * _ringRadiusFactor * scale;
 
             // 计算线段起止点
@@ -132,8 +128,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
             ref readonly var pose = ref compos.t1;
 
             // 计算起点位置和半径
-            var sourceInCanvas3D = Vector3.Transform(pose.Translation, worldToViewport);
-            var sourceInCanvas = new Vector2(sourceInCanvas3D.X, sourceInCanvas3D.Y);
+            var sourceInCanvas = TransformProjection.To2D(Vector3.Transform(pose.Translation, worldToViewport));
             var sourceRingRadius = refSize.Radius * _ringRadiusFactor * scale;
 
             // 计算线段起止点

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/CountReachabilitySystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/CountReachabilitySystem.cs
@@ -3,7 +3,6 @@ using Arch.Core.Extensions;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Utils;
-using Barrier = OpenSolarMax.Mods.Core.Components.Barrier;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -12,7 +11,7 @@ public delegate bool? CheckPlanetReachabilityCallback(World world,
                                                       Entity destination, in AbsoluteTransform destinationPose);
 
 [SimulateSystem, AfterStructuralChanges]
-[ReadCurr(typeof(AbsoluteTransform)), ReadCurr(typeof(Barrier)), Write(typeof(ReachabilityRegistry))]
+[ReadCurr(typeof(AbsoluteTransform)), ReadCurr(typeof(InfiniteZBarrier)), Write(typeof(ReachabilityRegistry))]
 [ExecuteAfter(typeof(ApplyAnimationSystem))]
 public class CountReachabilitySystem(World world) : ICalcSystem
 {

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Transportation/TransportUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Transportation/TransportUnitsSystem.cs
@@ -67,12 +67,7 @@ public partial class ApplyUnitsTransportationEffectSystem(World world, IAssetsMa
                                                            .TransformToParent;
             var tail = (expectedPoseInDestination * destinationPlanetPose).Translation;
 
-            var vector = tail - head;
-            var unitX = Vector3.Normalize(vector);
-            var unitY = Vector3.Normalize(new(-vector.Y, vector.X, 0));
-            var unitZ = Vector3.Cross(unitX, unitY);
-            var rotation = new Matrix { Right = unitX, Up = unitY, Backward = unitZ };
-            pose.Rotation = Quaternion.CreateFromRotationMatrix(rotation);
+            pose.Rotation = TransformProjection.UprightAim(tail - head);
 
             // 播放动画
             var animationTime = (float)status.PreTransportation.ElapsedTime.TotalSeconds;

--- a/OpenSolarMax.Mods.Core/Utils/ManeuveringUtils.cs
+++ b/OpenSolarMax.Mods.Core/Utils/ManeuveringUtils.cs
@@ -1,35 +1,37 @@
+using System.Runtime.CompilerServices;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Microsoft.Xna.Framework;
 using OpenSolarMax.Mods.Core.Components;
-using Barrier = OpenSolarMax.Mods.Core.Components.Barrier;
 
 namespace OpenSolarMax.Mods.Core.Utils;
 
 public static class ManeuveringUtils
 {
-    private static readonly QueryDescription _barrierDesc = new QueryDescription().WithAll<Barrier>();
+    private static readonly QueryDescription _barrierDesc = new QueryDescription().WithAll<InfiniteZBarrier>();
 
-    public static bool CheckBarriersBlocking(World world, Vector3 departure, Vector3 destination)
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float CrossProduct(Vector2 a, Vector2 b) => a.X * b.Y - a.Y * b.X;
+
+    public static bool CheckBarriersBlocking(World world, Vector2 departure, Vector2 destination)
     {
-        departure.Z = destination.Z = 0;
-
         var query = world.Query(in _barrierDesc);
         foreach (var chunk in query.GetChunkIterator())
         {
-            var barrierSpan = chunk.GetSpan<Barrier>();
+            var barrierSpan = chunk.GetSpan<InfiniteZBarrier>();
             foreach (var idx in chunk)
             {
                 ref readonly var barrier = ref barrierSpan[idx];
-                var head = barrier.Head with { Z = 0 };
-                var tail = barrier.Tail with { Z = 0 };
+                var head = barrier.Head;
+                var tail = barrier.Tail;
 
-                var cross1 = Vector3.Cross(departure - head, destination - head);
-                var cross2 = Vector3.Cross(departure - tail, destination - tail);
-                var cross3 = Vector3.Cross(head - departure, tail - departure);
-                var cross4 = Vector3.Cross(head - destination, tail - destination);
+                var cross1 = CrossProduct(departure - head, destination - head);
+                var cross2 = CrossProduct(departure - tail, destination - tail);
+                var cross3 = CrossProduct(head - departure, tail - departure);
+                var cross4 = CrossProduct(head - destination, tail - destination);
 
-                if (cross1.Z * cross2.Z <= 0 && cross3.Z * cross4.Z <= 0)
+                if (cross1 * cross2 <= 0 && cross3 * cross4 <= 0)
                     return true;
             }
         }
@@ -37,6 +39,11 @@ public static class ManeuveringUtils
         return false;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CheckBarriersBlocking(World world, Vector3 departure, Vector3 destination) =>
+        CheckBarriersBlocking(world, new Vector2(departure.X, departure.Y), new Vector2(destination.X, destination.Y));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool CheckBarriersBlocking(World world, Entity departure, Entity destination)
         => CheckBarriersBlocking(world,
                                  departure.Get<AbsoluteTransform>().Translation,

--- a/OpenSolarMax.Mods.Core/Utils/TransformProjection.cs
+++ b/OpenSolarMax.Mods.Core/Utils/TransformProjection.cs
@@ -1,0 +1,83 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Xna.Framework;
+
+namespace OpenSolarMax.Mods.Core.Utils;
+
+/// <summary>
+/// 负责在 2D 坐标系和 3D 坐标系之间转换的工具方法
+/// </summary>
+public static class TransformProjection
+{
+    /// <summary>
+    /// 将 2D 向量转换为 3D 向量。转换后的 3D 向量 Z 轴为 0
+    /// </summary>
+    /// <param name="vector">XY 平面上的 2D 向量</param>
+    /// <returns>Z 轴为 0 的 3D 向量</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 To3D(Vector2 vector) => new(vector, 0);
+
+    /// <summary>
+    /// 将 XY 平面上的旋转转换为 3D 旋转四元数格式。转换后的 3D 旋转将严格位于 XY 平面上
+    /// </summary>
+    /// <param name="rotation">XY 平面上从 X 轴逆时针旋转的弧度</param>
+    /// <returns>XY 平面上的 3D 旋转</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Quaternion To3D(float rotation) => Quaternion.CreateFromAxisAngle(Vector3.UnitZ, rotation);
+
+    /// <summary>
+    /// 将 2D 坐标和旋转转换为 3D 坐标和旋转。转换后的 3D 位姿将严格位于 XY 平面上。<br/>
+    /// 该方法本质上为结合 <see cref="To3D(Vector2)"/> 和 <see cref="To3D(float)"/> 的语法糖
+    /// </summary>
+    /// <param name="position">XY 平面上的 2D 坐标</param>
+    /// <param name="rotation">XY 平面上从 X 轴逆时针旋转的弧度</param>
+    /// <returns>3D 坐标系中的位姿</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (Vector3, Quaternion) To3D(Vector2 position, float rotation) => (To3D(position), To3D(rotation));
+
+    /// <summary>
+    /// 将 3D 向量投影到 2D XY 平面上
+    /// </summary>
+    /// <param name="vector">3D 向量</param>
+    /// <returns>XY 平面上的 2D 向量</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector2 To2D(Vector3 vector) => new(vector.X, vector.Y);
+
+    /// <summary>
+    /// 将 3D 旋转投影到 2D XY 平面上
+    /// </summary>
+    /// <param name="rotation">3D 旋转的四元数</param>
+    /// <returns>XY 平面上从 X 轴逆时针旋转的弧度</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float To2D(Quaternion rotation)
+    {
+        // 获取经过 3D 旋转后的 X 方向向量
+        var rotatedUnitX = Vector3.Transform(Vector3.UnitX, Matrix.CreateFromQuaternion(rotation));
+        // 投影方向向量
+        var projectedUnitX = To2D(rotatedUnitX);
+        // 计算投影后的旋转
+        return MathF.Atan2(projectedUnitX.Y, projectedUnitX.X);
+    }
+
+    /// <summary>
+    /// 将 3D 位姿投影到 2D XY 平面上。<br/>
+    /// 该方法本质上为结合 <see cref="To2D(Vector3)"/> 和 <see cref="To2D(Quaternion)"/> 的语法糖
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="rotation"></param>
+    /// <returns></returns>
+    public static (Vector2, float) To2D(Vector3 position, Quaternion rotation) => (To2D(position), To2D(rotation));
+
+    /// <summary>
+    /// 使位姿的 X 轴指向目标方向，同时将 Z 轴约束在 X 轴与世界 Z 轴构成的平面内，从而让贴图尽可能面向世界 XY 平面
+    /// </summary>
+    /// <param name="vector">姿态 X 轴必须指向的方向</param>
+    /// <returns>一个 3D 旋转四元数，使姿态尽量面向 XY 平面</returns>
+    public static Quaternion UprightAim(Vector3 vector)
+    {
+        var unitX = Vector3.Normalize(vector);
+        var unitY = Vector3.Normalize(new Vector3(-unitX.Y, unitX.X, 0));
+        var unitZ = Vector3.Cross(unitX, unitY);
+        var rotation = new Matrix { Right = unitX, Up = unitY, Backward = unitZ };
+        return Quaternion.CreateFromRotationMatrix(rotation);
+    }
+}


### PR DESCRIPTION
1. Clarified the usage scope of the 2D and 3D coordinate systems: The 3D coordinate system is used exclusively in internal implementations, while all external interfaces operate in 2D.
2. Following this principle, fixed the initialization interface of `Barrier` and renamed it to `InfiniteZBarrier` to reflect its infinite-length characteristic in the 3D world.
3. Provided standard interfaces for converting between the 2D and 3D coordinate systems, ensuring consistent usage across the codebase.

---

1. 明确划分了 2D 坐标系和 3D 坐标系的使用范围：在且仅在内部实现上使用 3D 坐标系，对外的接口统统为 2D；
2. 根据上述原则修复了 `Barrier` 的初始化接口，并将其命名为 `InfiniteZBarrier` 以展示其在 3D 世界中的无限长特性；
3. 提供了在 2D 坐标系和 3D 坐标系之间转换的标准接口，统一各处使用。