### PR TITLE
修复章节过渡界面中的卡顿问题

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "csharpier"
       ],
       "rollForward": false
+    },
+    "dotnet-trace": {
+      "version": "9.0.661903",
+      "commands": [
+        "dotnet-trace"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/OpenSolarMax.Game/Screens/Transitions/ChapterTransition.cs
+++ b/OpenSolarMax.Game/Screens/Transitions/ChapterTransition.cs
@@ -75,18 +75,19 @@ internal class ChapterTransitionScreen(
 
     public override void Update(GameTime gameTime)
     {
-        // 检查下一个界面是否加载完毕
-        var nextScreen = NextScreen;
-
-        // 前后界面各自照常更新
-        prevScreen.Update(gameTime);
-        nextScreen?.Update(gameTime);
-
         // 执行状态下更新
         if (_stage == Stage.First || _stage == Stage.Second)
         {
             _duration += gameTime.ElapsedGameTime;
         }
+        (
+            _stage switch
+            {
+                Stage.First => prevScreen as IScreen,
+                Stage.Second => nextScreenTask.Result,
+                _ => null,
+            }
+        )?.Update(gameTime);
 
         // 切换内部状态
         if (_stage == Stage.Start)
@@ -105,19 +106,19 @@ internal class ChapterTransitionScreen(
             _duration = TimeSpan.Zero;
             prevScreen.ExitConfigurationMode();
         }
-        else if (_stage == Stage.Wait && nextScreen is not null)
+        else if (_stage == Stage.Wait && nextScreenTask.IsCompleted)
         {
             // 处于等待阶段且下一个界面加载完成时, 进入第二阶段
             _stage = Stage.Second;
             _duration = TimeSpan.Zero;
-            nextScreen!.EnterConfigurationMode();
+            nextScreenTask.Result.EnterConfigurationMode();
         }
         else if (_stage == Stage.Second && _duration >= _secondStageDuration)
         {
             // 处于第二阶段且时间足够时, 结束过渡
             _stage = Stage.Stop;
             _duration = TimeSpan.Zero;
-            nextScreen!.ExitConfigurationMode();
+            nextScreenTask.Result.ExitConfigurationMode();
             OnTransitionDone();
         }
     }
@@ -150,7 +151,7 @@ internal class ChapterTransitionScreen(
         }
         else if (_stage is Stage.Second or Stage.Stop)
         {
-            var nextScreen = NextScreen;
+            var nextScreen = nextScreenTask.Result;
             var progress = _stage is Stage.Stop ? 1 : (float)(_duration / _secondStageDuration);
 
             // 更新后一个界面的视觉效果

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -24,11 +24,9 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
         LevelRuntime Context
     )> _loadedLevelPreviews;
 
-    private readonly LevelRuntimeLoader _gameplayRuntimeLoader;
+    private readonly Task<LevelRuntimeLoader> _gameplayRuntimeLoaderTask;
     private readonly int _warmupLevelIndex;
     private readonly Task<LevelRuntime> _warmupLevelRuntimeLoadTask;
-
-    private Task<LevelRuntime>? _levelRuntimeLoadTask;
 
     #endregion
 
@@ -75,10 +73,11 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
         _pageBackground = background;
 
         // 生成游戏运行时加载器
-        _gameplayRuntimeLoader = new LevelRuntimeLoader(
-            _levelModContext,
-            GameplayOrPreview.Gameplay,
-            game
+        _gameplayRuntimeLoaderTask = Task.Factory.StartNew(
+            () => new LevelRuntimeLoader(_levelModContext, GameplayOrPreview.Gameplay, game),
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            game.BackgroundScheduler
         );
 
         // 生成小字
@@ -98,12 +97,17 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
 
         // 使用当前第一个显示的章节做启动预热
         _warmupLevelIndex = _primaryItemIndex;
-        _warmupLevelRuntimeLoadTask = Task.Factory.StartNew(
-            () => _gameplayRuntimeLoader.LoadLevel(_loadedLevelPreviews[_warmupLevelIndex].Level),
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            game.BackgroundScheduler
-        );
+        _warmupLevelRuntimeLoadTask = Task
+            .Factory.StartNew(
+                async () =>
+                    (await _gameplayRuntimeLoaderTask).LoadLevel(
+                        _loadedLevelPreviews[_warmupLevelIndex].Level
+                    ),
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                game.BackgroundScheduler
+            )
+            .Unwrap();
     }
 
     public event EventHandler<IViewModel>? NavigateIn;
@@ -133,7 +137,7 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
         var levelRuntime =
             idx == _warmupLevelIndex
                 ? _warmupLevelRuntimeLoadTask.Result
-                : _gameplayRuntimeLoader.LoadLevel(_loadedLevelPreviews[idx].Level);
+                : _gameplayRuntimeLoaderTask.Result.LoadLevel(_loadedLevelPreviews[idx].Level);
 
         Game.NavigationService.Navigate(
             typeof(LevelPlayPage),


### PR DESCRIPTION
卡顿来自两点：

- 章节过渡界面中，每次 `Update` 都尝试获取下一界面，这样当下一界面的 Context 完成加载后就会立刻在主循环中加载下一界面的 View 和 ViewModel，而不是在正确的 `Wait` 阶段去加载。
- 章节 ViewModel 中，在构造函数中嵌入了游玩场景下的 `LevelRuntimeLoader` 的构造，导致了卡顿。这一构造也应当放在后台线程去做。