### PR TITLE
基于 IDisposable 为模组上下文和相关界面应用生命周期管理和资源释放

### DIFF
--- a/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
+++ b/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
@@ -11,13 +11,23 @@ using OpenSolarMax.Game.Modding.ECS;
 
 namespace OpenSolarMax.Game.Level;
 
-internal record LevelRuntime(
+internal sealed record LevelRuntime(
     World World,
     AggregateSystem InputSystems,
     AggregateSystem AiSystems,
     AggregateSystem SimulateSystems,
     AggregateSystem RenderSystems
-);
+) : IDisposable
+{
+    public void Dispose()
+    {
+        World.Dispose();
+        InputSystems.Dispose();
+        AiSystems.Dispose();
+        SimulateSystems.Dispose();
+        RenderSystems.Dispose();
+    }
+}
 
 internal class LevelRuntimeLoader
 {

--- a/OpenSolarMax.Game/Modding/BehaviorMod.cs
+++ b/OpenSolarMax.Game/Modding/BehaviorMod.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection;
+using System.Runtime.Loader;
 using CsToml.Extensions.Configuration;
 using Microsoft.Extensions.Configuration;
 using Nine.Assets;
@@ -12,7 +13,7 @@ namespace OpenSolarMax.Game.Modding;
 
 internal record ConceptRelatedTypes(Type? Definition, Type? Description, Type? Applier);
 
-internal class BehaviorMod
+internal class BehaviorMod : IDisposable
 {
     public BehaviorModInfo Metadata { get; }
 
@@ -71,7 +72,11 @@ internal class BehaviorMod
         // 加载资产文件系统
         List<IFileSystem> contentFileSystems = [new ResourceFileSystem(Assembly)];
         if (info.Content is not null)
-            contentFileSystems.Add(new SubFileSystem(info.Content.FileSystem, info.Content.Path));
+        {
+            contentFileSystems.Add(
+                new SubFileSystem(info.Content.FileSystem, info.Content.Path, owned: false)
+            );
+        }
         ContentFileSystems = contentFileSystems.ToImmutableArray();
 
         // 加载配置文件
@@ -124,5 +129,22 @@ internal class BehaviorMod
                 .FindHookImplementations(Assembly, GameplayOrPreview.Preview)
                 .ToImmutableDictionary(g => g.Key, g => g.ToImmutableArray())
         );
+    }
+
+    private bool _disposed = false;
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        // 启动 ALC 卸载
+        AssemblyLoadContext.GetLoadContext(Assembly)!.Unload();
+
+        // 释放资产文件系统
+        foreach (var fs in ContentFileSystems)
+            fs.Dispose();
+
+        _disposed = true;
     }
 }

--- a/OpenSolarMax.Game/Modding/ContentMod.cs
+++ b/OpenSolarMax.Game/Modding/ContentMod.cs
@@ -4,7 +4,7 @@ using Zio.FileSystems;
 
 namespace OpenSolarMax.Game.Modding;
 
-internal class ContentMod
+internal class ContentMod : IDisposable
 {
     public ContentModInfo Metadata { get; }
 
@@ -18,6 +18,16 @@ internal class ContentMod
         Metadata = info;
 
         // 加载资产文件系统
-        ContentFileSystems = [new SubFileSystem(info.Content.FileSystem, info.Content.Path)];
+        ContentFileSystems =
+        [
+            new SubFileSystem(info.Content.FileSystem, info.Content.Path, owned: false),
+        ];
+    }
+
+    public void Dispose()
+    {
+        // 释放资产文件系统
+        foreach (var fs in ContentFileSystems)
+            fs.Dispose();
     }
 }

--- a/OpenSolarMax.Game/Modding/ECS/AggregateSystem.cs
+++ b/OpenSolarMax.Game/Modding/ECS/AggregateSystem.cs
@@ -6,7 +6,7 @@ using Microsoft.Xna.Framework;
 
 namespace OpenSolarMax.Game.Modding.ECS;
 
-internal class AggregateSystem
+internal class AggregateSystem : IDisposable
 {
     private static void RegisterHook(
         IEnumerable<object> systems,
@@ -111,5 +111,22 @@ internal class AggregateSystem
     {
         Debug.Assert(_commandBuffer.Size == 0);
         LateUpdateImpl();
+    }
+
+    public void Dispose()
+    {
+        // 释放 CommandBuffer
+        _commandBuffer.Dispose();
+
+        // 释放所有内部系统
+        foreach (
+            var sys in _beforeStructuralChangesSystems
+                .Concat(_reactToStructuralChangeSystems)
+                .Concat(_afterStructuralChangesSystems)
+        )
+        {
+            if (sys is IDisposable disposable)
+                disposable.Dispose();
+        }
     }
 }

--- a/OpenSolarMax.Game/Modding/LevelModContext.cs
+++ b/OpenSolarMax.Game/Modding/LevelModContext.cs
@@ -13,7 +13,7 @@ using Zio.FileSystems;
 
 namespace OpenSolarMax.Game.Modding;
 
-internal class LevelModContext
+internal class LevelModContext : IDisposable
 {
     public LevelModInfo Metadata { get; }
 
@@ -102,6 +102,18 @@ internal class LevelModContext
         );
     }
 
+    public void Dispose()
+    {
+        // 释放资产缓存
+        LocalAssets.Dispose();
+
+        // 释放模组自身信息
+        foreach (var mod in BehaviorMods)
+            mod.Dispose();
+        foreach (var mod in ContentMods)
+            mod.Dispose();
+    }
+
     public LevelModContext(LevelModInfo info, SolarMax game)
     {
         Metadata = info;
@@ -158,7 +170,7 @@ internal class LevelModContext
         #region 构建局部资产
 
         // 构造局部资产层叠文件系统
-        var localFileSystem = new AggregateFileSystem();
+        var localFileSystem = new AggregateFileSystem(owned: false); // 局部资产不持有模组的文件系统所有权
         // 全局资产位于最底层
         localFileSystem.AddFileSystem(Folders.Content);
         // 逐个添加资产文件系统

--- a/OpenSolarMax.Game/Modding/ModLoadContext.cs
+++ b/OpenSolarMax.Game/Modding/ModLoadContext.cs
@@ -8,7 +8,7 @@ namespace OpenSolarMax.Game.Modding;
 internal class ModLoadContext(
     FileEntry file,
     IReadOnlyDictionary<string, Assembly> sharedAssemblies
-) : AssemblyLoadContext
+) : AssemblyLoadContext(isCollectible: true)
 {
     private static string GetPhysicalPath(FileEntry fileEntry)
     {

--- a/OpenSolarMax.Game/Screens/Pages/InitializationPage.cs
+++ b/OpenSolarMax.Game/Screens/Pages/InitializationPage.cs
@@ -1,0 +1,7 @@
+using OpenSolarMax.Game.Screens.ViewModels;
+using OpenSolarMax.Game.Screens.Views;
+
+namespace OpenSolarMax.Game.Screens.Pages;
+
+internal class InitializationPage(SolarMax game)
+    : InitializationView(new InitializationViewModel(game), game);

--- a/OpenSolarMax.Game/Screens/ViewModels/IViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/IViewModel.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework;
 
 namespace OpenSolarMax.Game.Screens.ViewModels;
 
-public interface IViewModel : INotifyPropertyChanged, INotifyPropertyChanging
+public interface IViewModel : INotifyPropertyChanged, INotifyPropertyChanging, IDisposable
 {
     void Update(GameTime gameTime);
 }

--- a/OpenSolarMax.Game/Screens/ViewModels/InitializationViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/InitializationViewModel.cs
@@ -115,7 +115,7 @@ internal partial class InitializationViewModel : ViewModelBase, ILoaderViewModel
         )
         {
             LoadCompleted = true;
-            Game.NavigationService.Forward(typeof(MainMenuPage), _levelPreviewsLoadTask.Result);
+            Game.ScreenManager.Forward(typeof(MainMenuPage), _levelPreviewsLoadTask.Result);
         }
     }
 }

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
@@ -81,4 +81,10 @@ internal partial class LevelPlayViewModel : ViewModelBase
         _runtime.AiSystems.Update(_playTime);
         _runtime.SimulateSystems.Update(_playTime);
     }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _runtime.Dispose();
+    }
 }

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
@@ -63,7 +63,7 @@ internal partial class LevelPlayViewModel : ViewModelBase
 
     private void OnExit()
     {
-        Game.NavigationService.Backward(typeof(BackwardGamePlayTransitionScreen));
+        Game.ScreenManager.Backward(typeof(BackwardGamePlayTransitionScreen));
     }
 
     public override void Update(GameTime gameTime)

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -165,4 +165,10 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
     {
         base.Update(gameTime);
     }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _levelModContext.Dispose();
+    }
 }

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -165,10 +165,4 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
     {
         base.Update(gameTime);
     }
-
-    public override void Dispose()
-    {
-        base.Dispose();
-        _levelModContext.Dispose();
-    }
 }

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -25,8 +25,7 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
     )> _loadedLevelPreviews;
 
     private readonly Task<LevelRuntimeLoader> _gameplayRuntimeLoaderTask;
-    private readonly int _warmupLevelIndex;
-    private readonly Task<LevelRuntime> _warmupLevelRuntimeLoadTask;
+    private Task<LevelRuntime>? _warmupLevelRuntimeLoadTask;
 
     #endregion
 
@@ -103,12 +102,11 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
         _secondaryItemBackground = null;
 
         // 使用当前第一个显示的章节做启动预热
-        _warmupLevelIndex = _primaryItemIndex;
         _warmupLevelRuntimeLoadTask = Task
             .Factory.StartNew(
                 async () =>
                     (await _gameplayRuntimeLoaderTask).LoadLevel(
-                        _loadedLevelPreviews[_warmupLevelIndex].Level
+                        _loadedLevelPreviews[_primaryItemIndex].Level
                     ),
                 CancellationToken.None,
                 TaskCreationOptions.None,
@@ -141,10 +139,18 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
 
     private void OnSelectItem(int idx)
     {
-        var levelRuntime =
-            idx == _warmupLevelIndex
-                ? _warmupLevelRuntimeLoadTask.Result
-                : _gameplayRuntimeLoaderTask.Result.LoadLevel(_loadedLevelPreviews[idx].Level);
+        if (_warmupLevelRuntimeLoadTask is not null)
+        {
+            // 如果存在预热任务, 则等待预热任务完成
+            _warmupLevelRuntimeLoadTask.Wait();
+            _warmupLevelRuntimeLoadTask.Dispose();
+            _warmupLevelRuntimeLoadTask = null;
+        }
+
+        // 不复用预热结果, 每次都重新加载新的运行时
+        var levelRuntime = _gameplayRuntimeLoaderTask.Result.LoadLevel(
+            _loadedLevelPreviews[idx].Level
+        );
 
         Game.NavigationService.Forward(
             typeof(LevelPlayPage),

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -152,7 +152,7 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
             _loadedLevelPreviews[idx].Level
         );
 
-        Game.NavigationService.Forward(
+        Game.ScreenManager.Forward(
             typeof(LevelPlayPage),
             new LevelPlayPageContext(levelRuntime, PageBackground),
             typeof(GamePlayTransitionScreen)
@@ -161,7 +161,7 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
 
     private void OnBackward()
     {
-        Game.NavigationService.Backward(
+        Game.ScreenManager.Backward(
             typeof(BackwardChapterTransitionScreen),
             new ChapterTransitionContext(PageBackground)
         );

--- a/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
@@ -28,6 +28,8 @@ internal partial class MainMenuViewModel : ViewModelBase, IMenuLikeViewModel, IV
 
     private readonly List<PreviewableLevelMod> _levelMods;
 
+    private Tuple<int, Task<object?>>? _previousChapterPageContextPair = null;
+
     #endregion
 
     [ObservableProperty]
@@ -157,16 +159,36 @@ internal partial class MainMenuViewModel : ViewModelBase, IMenuLikeViewModel, IV
     {
         if (idx < _builtinPreviews.Count)
             return;
-        Game.NavigationService.Forward2(
-            typeof(ChapterPage),
-            Task<object?>.Factory.StartNew(
-                () => Load(_levelMods[idx - _builtinPreviews.Count], Game),
+        var levelModIndex = idx - _builtinPreviews.Count;
+        var contextLoadTask = _previousChapterPageContextPair switch
+        {
+            { } prev when prev?.Item1 == levelModIndex => prev.Item2,
+            { } prev => Task
+                .Factory.StartNew(
+                    async () =>
+                    {
+                        var previousChapterPageContext = (ChapterPageContext)(await prev.Item2)!;
+                        previousChapterPageContext.LevelModContext.Dispose();
+                        return (object?)Load(_levelMods[levelModIndex], Game);
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    Game.BackgroundScheduler
+                )
+                .Unwrap(),
+            null => Task<object?>.Factory.StartNew(
+                () => Load(_levelMods[levelModIndex], Game),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 Game.BackgroundScheduler
             ),
+        };
+        _previousChapterPageContextPair = new(levelModIndex, contextLoadTask);
+        Game.NavigationService.Forward2(
+            typeof(ChapterPage),
+            contextLoadTask,
             typeof(ChapterTransitionScreen),
-            new ChapterTransitionContext(_levelMods[idx - _builtinPreviews.Count].Background!)
+            new ChapterTransitionContext(_levelMods[levelModIndex].Background!)
         );
     }
 

--- a/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
@@ -184,7 +184,7 @@ internal partial class MainMenuViewModel : ViewModelBase, IMenuLikeViewModel, IV
             ),
         };
         _previousChapterPageContextPair = new(levelModIndex, contextLoadTask);
-        Game.NavigationService.Forward2(
+        Game.ScreenManager.Forward2(
             typeof(ChapterPage),
             contextLoadTask,
             typeof(ChapterTransitionScreen),

--- a/OpenSolarMax.Game/Screens/ViewModels/ViewModelBase.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/ViewModelBase.cs
@@ -13,4 +13,6 @@ public abstract class ViewModelBase : ObservableObject, IViewModel
     }
 
     public virtual void Update(GameTime gameTime) { }
+
+    public virtual void Dispose() { }
 }

--- a/OpenSolarMax.Game/Screens/Views/ViewBase.cs
+++ b/OpenSolarMax.Game/Screens/Views/ViewBase.cs
@@ -22,5 +22,8 @@ internal abstract class ViewBase<T>(T viewModel, SolarMax game) : IScreen
 
     public abstract void Draw(GameTime gameTime);
 
-    public virtual void Dispose() { }
+    public virtual void Dispose()
+    {
+        viewModel.Dispose();
+    }
 }

--- a/OpenSolarMax.Game/SolarMax.cs
+++ b/OpenSolarMax.Game/SolarMax.cs
@@ -6,6 +6,7 @@ using Myra;
 using Nine.Assets;
 using Nine.Screens;
 using OpenSolarMax.Game.Screens;
+using OpenSolarMax.Game.Screens.Pages;
 using OpenSolarMax.Game.Screens.ViewModels;
 using OpenSolarMax.Game.Screens.Views;
 using OpenSolarMax.Game.Utils;
@@ -23,7 +24,6 @@ public class SolarMax : XNAGame
     private FmodStudioSystem _globalFmodSystem;
 
     private ScreenManager _globalScreenManager;
-    private NavigationService _globalNavigationService;
     private RenderTarget2D _renderTarget;
     private SpriteBatch _spriteBatch;
 
@@ -58,7 +58,7 @@ public class SolarMax : XNAGame
 
     public AssetsManager Assets => _globalAssets;
 
-    internal NavigationService NavigationService => _globalNavigationService;
+    internal ScreenManager ScreenManager => _globalScreenManager;
 
     private void PreparingDeviceSettings(object? sender, PreparingDeviceSettingsEventArgs e)
     {
@@ -104,23 +104,15 @@ public class SolarMax : XNAGame
         _globalAssets = new AssetsManager(Folders.Content);
 
         // 初始化全局界面管理器
-        _globalScreenManager = new ScreenManager(this);
+        _globalScreenManager = new ScreenManager(new ScreenFactory(this), this);
         Components.Add(_globalScreenManager);
-
-        // 初始化全局导航服务
-        _globalNavigationService = new NavigationService(
-            _globalScreenManager,
-            new ScreenFactory(this)
-        );
 
         base.Initialize();
     }
 
     protected override void LoadContent()
     {
-        var initializationViewModel = new InitializationViewModel(this);
-        var initializationScreen = new InitializationView(initializationViewModel, this);
-        _globalScreenManager.PushScreen(initializationScreen);
+        _globalScreenManager.Forward(typeof(InitializationPage));
     }
 
     protected override void UnloadContent()

--- a/OpenSolarMax.Mods.Core/Concepts/HaloExplosion.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/HaloExplosion.cs
@@ -6,7 +6,6 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -52,9 +51,8 @@ public class HaloExplosionApplier(IAssetsManager assets) : IApplier<HaloExplosio
         "Animations/HaloExplosion.json"
     );
 
-    private FmodEventDescription _colonizedSoundEvent = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/PlanetColonized"
-    );
+    private readonly SafeFmodEventDescription _colonizedSoundEvent =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/PlanetColonized");
 
     public void Apply(CommandBuffer commandBuffer, Entity entity, HaloExplosionDescription desc)
     {
@@ -90,7 +88,7 @@ public class HaloExplosionApplier(IAssetsManager assets) : IApplier<HaloExplosio
         );
 
         // 设置音效
-        _colonizedSoundEvent.createInstance(out var eventInstance);
+        _colonizedSoundEvent.Native.createInstance(out var eventInstance);
         commandBuffer.Set(in entity, new SoundEffect { EventInstance = eventInstance });
         eventInstance.start();
     }

--- a/OpenSolarMax.Mods.Core/Concepts/LaserBeam.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/LaserBeam.cs
@@ -8,7 +8,6 @@ using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Utils;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -54,9 +53,8 @@ public class LaserBeamApplier(IAssetsManager assets, IConceptFactory factory)
         "Animations/LaserBeam.json"
     );
 
-    private readonly FmodEventDescription _laserSoundEffect = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/LaserShoot"
-    );
+    private readonly SafeFmodEventDescription _laserSoundEffect =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/LaserShoot");
 
     public void Apply(CommandBuffer commandBuffer, Entity entity, LaserBeamDescription desc)
     {
@@ -105,7 +103,7 @@ public class LaserBeamApplier(IAssetsManager assets, IConceptFactory factory)
         );
 
         // 设置音效
-        _laserSoundEffect.createInstance(out var eventInstance);
+        _laserSoundEffect.Native.createInstance(out var eventInstance);
         commandBuffer.Set(in entity, new SoundEffect { EventInstance = eventInstance });
         eventInstance.start();
     }

--- a/OpenSolarMax.Mods.Core/Concepts/PortalChargingEffect.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/PortalChargingEffect.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Nine.Assets;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -40,9 +39,8 @@ public class PortalChargingEffectDescription : IDescription
 public class PortalChargingEffectApplier(IAssetsManager assets, IConceptFactory factory)
     : IApplier<PortalChargingEffectDescription>
 {
-    private FmodEventDescription _warpChargingSoundEffect = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/WarpCharging"
-    );
+    private readonly SafeFmodEventDescription _warpChargingSoundEffect =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/WarpCharging");
 
     public void Apply(
         CommandBuffer commandBuffer,
@@ -124,7 +122,7 @@ public class PortalChargingEffectApplier(IAssetsManager assets, IConceptFactory 
             }
         );
 
-        _warpChargingSoundEffect.createInstance(out var eventInstance);
+        _warpChargingSoundEffect.Native.createInstance(out var eventInstance);
         commandBuffer.Set(in entity, new SoundEffect { EventInstance = eventInstance });
         eventInstance.start();
     }

--- a/OpenSolarMax.Mods.Core/Concepts/SimpleSound.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/SimpleSound.cs
@@ -4,7 +4,6 @@ using Nine.Assets;
 using OneOf;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -30,7 +29,7 @@ public abstract class SimpleSoundDefinition : IDefinition
 [Describe(ConceptNames.SimpleSound)]
 public class SimpleSoundDescription : IDescription
 {
-    public required OneOf<string, FmodEventDescription> SoundEffect { get; set; }
+    public required OneOf<string, SafeFmodEventDescription> SoundEffect { get; set; }
 
     public OneOf<
         AbsoluteTransformOptions,
@@ -56,10 +55,10 @@ public class SimpleSoundApplier(IAssetsManager assets, IConceptFactory factory)
 
         // 创建音频实例
         var soundEffect = desc.SoundEffect.Match(
-            path => assets.Load<FmodEventDescription>(path),
+            path => assets.Load<SafeFmodEventDescription>(path),
             fx => fx
         );
-        soundEffect.createInstance(out var eventInstance);
+        soundEffect.Native.createInstance(out var eventInstance);
         commandBuffer.Set(in entity, new SoundEffect { EventInstance = eventInstance });
         eventInstance.start();
     }

--- a/OpenSolarMax.Mods.Core/Concepts/UnitFlare.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/UnitFlare.cs
@@ -6,7 +6,6 @@ using Nine.Assets;
 using Nine.Graphics;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Mods.Core.Components;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Concepts;
 
@@ -50,9 +49,8 @@ public class UnitFlareApplier(IAssetsManager assets) : IApplier<UnitFlareDescrip
         "Animations/UnitFlare.json"
     );
 
-    private FmodEventDescription _destroyedSoundEvent = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/UnitDestroyed"
-    );
+    private readonly SafeFmodEventDescription _destroyedSoundEvent =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/UnitDestroyed");
 
     public void Apply(CommandBuffer commandBuffer, Entity entity, UnitFlareDescription desc)
     {
@@ -85,7 +83,7 @@ public class UnitFlareApplier(IAssetsManager assets) : IApplier<UnitFlareDescrip
         );
 
         // 设置音效
-        _destroyedSoundEvent.createInstance(out var eventInstance);
+        _destroyedSoundEvent.Native.createInstance(out var eventInstance);
         commandBuffer.Set(in entity, new SoundEffect { EventInstance = eventInstance });
         eventInstance.start();
     }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/LandArrivedShipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/LandArrivedShipsSystem.cs
@@ -8,7 +8,6 @@ using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Concepts;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -35,9 +34,8 @@ public sealed partial class LandArrivedShipsSystem(
 {
     private readonly List<Entity> _arrivedEntities = [];
 
-    private FmodEventDescription _travelDoneSoundEvent = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/ShipDone"
-    );
+    private readonly SafeFmodEventDescription _travelDoneSoundEvent =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/ShipDone");
 
     [Query]
     [All<ShippingStatus>]
@@ -96,7 +94,7 @@ public sealed partial class LandArrivedShipsSystem(
         commandBuffer.Destroy(ship.Get<TrailOf.AsShip>().Relationship!.Value.Copy.Trail);
 
         // 播放音效
-        _travelDoneSoundEvent.createInstance(out var instance);
+        _travelDoneSoundEvent.Native.createInstance(out var instance);
         soundEffect.EventInstance = instance;
         instance.start();
     }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/StartShippingSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/StartShippingSystem.cs
@@ -13,7 +13,6 @@ using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Concepts;
 using OpenSolarMax.Mods.Core.Utils;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -49,9 +48,8 @@ public sealed partial class StartShippingSystem(
     [Section("systems:simulate:shipping")] IConfiguration configs
 ) : ICalcSystemWithStructuralChanges
 {
-    private FmodEventDescription _chargingSoundEvent = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/ShipCharging"
-    );
+    private readonly SafeFmodEventDescription _chargingSoundEvent =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/ShipCharging");
 
     private readonly float _offsetTime = configs.RequireValue<float>("arrival_time_offset");
     private readonly float _maxOffsetRatio = configs.RequireValue<float>(
@@ -157,7 +155,7 @@ public sealed partial class StartShippingSystem(
             );
 
             // 发出声音
-            _chargingSoundEvent.createInstance(out var instance);
+            _chargingSoundEvent.Native.createInstance(out var instance);
             ship.Get<SoundEffect>().EventInstance = instance;
             instance.start();
 

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/TransitFromChargingToTravellingSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Shipping/TransitFromChargingToTravellingSystem.cs
@@ -6,7 +6,6 @@ using Nine.Assets;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -26,9 +25,8 @@ public sealed partial class TransitFromChargingToTravellingSystem(
 {
     private readonly float _chargingDuration = configs.RequireValue<float>("charging_duration");
 
-    private FmodEventDescription _travelBegunSoundEvent = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/ShipBegun"
-    );
+    private readonly SafeFmodEventDescription _travelBegunSoundEvent =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/ShipBegun");
 
     [Query]
     [All<ShippingStatus, SoundEffect>]
@@ -47,7 +45,7 @@ public sealed partial class TransitFromChargingToTravellingSystem(
                 ElapsedTime = 0,
             };
 
-            _travelBegunSoundEvent.createInstance(out var instance);
+            _travelBegunSoundEvent.Native.createInstance(out var instance);
             soundEffect.EventInstance = instance;
             instance.start();
         }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Transportation/TransportUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Transportation/TransportUnitsSystem.cs
@@ -11,7 +11,6 @@ using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Concepts;
 using OpenSolarMax.Mods.Core.Utils;
-using FmodEventDescription = FMOD.Studio.EventDescription;
 
 namespace OpenSolarMax.Mods.Core.Systems.Transportation;
 
@@ -134,9 +133,8 @@ public partial class TransportUnitsSystem(
     IConceptFactory factory
 ) : ICalcSystemWithStructuralChanges
 {
-    private readonly FmodEventDescription _warpingSoundEffect = assets.Load<FmodEventDescription>(
-        "Sounds/Master.bank:/Warping"
-    );
+    private readonly SafeFmodEventDescription _warpingSoundEffect =
+        assets.Load<SafeFmodEventDescription>("Sounds/Master.bank:/Warping");
 
     [Query]
     [All<


### PR DESCRIPTION
- **修复界面退出时的资源泄漏**：之前退出章节界面后，模组上下文、关卡运行时、AssemblyLoadContext 等资源未被正确释放，导致内存泄漏。现在所有关键资源实现 `IDisposable`，退出时自动清理。
- **章节界面重入时复用已加载上下文**：从章节界面退回主菜单后再次进入同一章节，之前会重新加载整个模组。现在改为保留上下文，仅在切换到不同模组时才释放并重新加载，显著提升重入速度。
- **统一页面导航至 `ScreenManager`**：移除旧的 `NavigationService`，全面接入 Nine.Screens 的 `ScreenManager`，以应用 Nine 最新的界面生命周期管理修复。
- **关卡运行时不再复用预热实例**：每次进入关卡时重新构造运行时，避免预热实例残留状态导致的异常行为。