### PR TITLE
fix(screens): 修复过渡期间的竞态条件和视觉状态覆盖问题

### DIFF
--- a/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelPlayViewModel.cs
@@ -63,6 +63,9 @@ internal partial class LevelPlayViewModel : ViewModelBase
 
     private void OnExit()
     {
+        // 避免在正在过渡时触发过渡
+        if (Game.ScreenManager.Transitioning)
+            return;
         Game.ScreenManager.Backward();
     }
 

--- a/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/LevelsViewModel.cs
@@ -139,6 +139,10 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
 
     private void OnSelectItem(int idx)
     {
+        // 避免在正在过渡时触发过渡
+        if (Game.ScreenManager.Transitioning)
+            return;
+
         if (_warmupLevelRuntimeLoadTask is not null)
         {
             // 如果存在预热任务, 则等待预热任务完成
@@ -161,6 +165,9 @@ internal partial class LevelsViewModel : ViewModelBase, IMenuLikeViewModel
 
     private void OnBackward()
     {
+        // 避免在正在过渡时触发过渡
+        if (Game.ScreenManager.Transitioning)
+            return;
         Game.ScreenManager.Backward();
     }
 

--- a/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
+++ b/OpenSolarMax.Game/Screens/ViewModels/MainMenuViewModel.cs
@@ -157,6 +157,10 @@ internal partial class MainMenuViewModel : ViewModelBase, IMenuLikeViewModel, IV
 
     private void OnSelectItem(int idx)
     {
+        // 避免在正在过渡时触发过渡
+        if (Game.ScreenManager.Transitioning)
+            return;
+
         if (idx < _builtinPreviews.Count)
             return;
         var levelModIndex = idx - _builtinPreviews.Count;

--- a/OpenSolarMax.Game/Screens/Views/MenuLikeView.cs
+++ b/OpenSolarMax.Game/Screens/Views/MenuLikeView.cs
@@ -335,10 +335,14 @@ internal class MenuLikeView
         ViewModel.BackwardCommand!.Execute(null);
     }
 
+    public override void Update(GameTime gameTime)
+    {
+        base.Update(gameTime);
+        _scrollViewer.Update(gameTime);
+    }
+
     public override void Draw(GameTime gameTime)
     {
-        _scrollViewer.Update(gameTime);
-
         // 计算背景偏移
         if (_controlBackground && _lastThumbnailsOffset is not null)
         {


### PR DESCRIPTION
- 禁止在界面过渡进行中触发新的导航操作，避免过渡叠加。
- 修正菜单类界面的滚动更新时机，确保视觉状态可被正确覆写。

Close #52 