### PR TITLE
fix(simulate): 修复多个攻击系统导致的单位重复销毁

### DIFF
--- a/OpenSolarMax.Mods.Core/Components/UnitDeathState.cs
+++ b/OpenSolarMax.Mods.Core/Components/UnitDeathState.cs
@@ -1,0 +1,34 @@
+using OpenSolarMax.Game.Modding.ECS;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+///  Unit 当前所处的死亡阶段
+/// </summary>
+public enum DeathState
+{
+    /// <summary>
+    /// 存活，正常参与游戏逻辑
+    /// </summary>
+    Alive,
+
+    /// <summary>
+    /// 濒死，停止参与游戏逻辑，等待播放死亡特效
+    /// </summary>
+    Dying,
+
+    /// <summary>
+    /// 已死亡，特效已播放完毕，等待销毁
+    /// </summary>
+    Dead,
+}
+
+/// <summary>
+///  Unit 死亡状态组件。
+/// 所有 Unit 出生时即携带此组件，<see cref="State"/> 初始为 <see cref="DeathState.Alive"/>
+/// </summary>
+[Component]
+public struct UnitDeathState
+{
+    public DeathState State;
+}

--- a/OpenSolarMax.Mods.Core/Concepts/Ship.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Ship.cs
@@ -33,7 +33,8 @@ public abstract class ShipDefinition : IDefinition
             typeof(TrailOf.AsShip),
             typeof(ShippingStatus),
             typeof(PopulationCost),
-            typeof(TransportingStatus)
+            typeof(TransportingStatus),
+            typeof(UnitDeathState)
         );
 }
 
@@ -113,5 +114,8 @@ public class ShipApplier(IAssetsManager assets, IConceptFactory factory) : IAppl
 
         // 初始化传送状态
         commandBuffer.Set(in entity, new TransportingStatus { State = TransportingState.Idle });
+
+        // 初始化死亡状态
+        commandBuffer.Set(in entity, new UnitDeathState { State = DeathState.Alive });
     }
 }

--- a/OpenSolarMax.Mods.Core/Signatures.cs
+++ b/OpenSolarMax.Mods.Core/Signatures.cs
@@ -48,7 +48,8 @@ public static class Signatures
             typeof(Animation),
             typeof(TrailOf.AsShip),
             typeof(PopulationCost),
-            typeof(SoundEffect)
+            typeof(SoundEffect),
+            typeof(UnitDeathState)
         );
 
     public static readonly Signature PredefinedOrbit =

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Combat/SettleCombatSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Combat/SettleCombatSystem.cs
@@ -3,11 +3,8 @@ using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
 using Arch.System.SourceGenerator;
-using Nine.Assets;
-using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
-using OpenSolarMax.Mods.Core.Concepts;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
@@ -18,19 +15,13 @@ namespace OpenSolarMax.Mods.Core.Systems;
 [
     ReadPrev(typeof(AnchoredShipsRegistry)),
     ReadPrev(typeof(Combatable)),
-    ReadPrev(typeof(Sprite)),
-    ReadPrev(typeof(AbsoluteTransform)),
     Iterate(typeof(Battlefield)),
     ChangeStructure
 ]
 [ExecuteBefore(typeof(ApplyAnimationSystem))]
 // 先量变再质变
 [ExecuteAfter(typeof(ProgressCombatSystem))]
-public sealed partial class SettleCombatSystem(
-    World world,
-    IAssetsManager assets,
-    IConceptFactory factory
-) : ICalcSystemWithStructuralChanges
+public sealed partial class SettleCombatSystem(World world) : ICalcSystemWithStructuralChanges
 {
     [Query]
     [All<AnchoredShipsRegistry, Battlefield>]
@@ -54,25 +45,8 @@ public sealed partial class SettleCombatSystem(
 
                 var ship = shipEnumerator.Current;
 
-                var color = ship.Get<Sprite>().Color;
-                var position = ship.Get<AbsoluteTransform>().Translation;
-
-                // 生成闪光
-                factory.Make(
-                    world,
-                    commandBuffer,
-                    new UnitFlareDescription() { Color = color, Position = position }
-                );
-
-                // 生成冲击波
-                factory.Make(
-                    world,
-                    commandBuffer,
-                    new UnitPulseDescription() { Color = color, Position = position }
-                );
-
-                // 移除单位
-                commandBuffer.Destroy(ship);
+                ref var deathState = ref ship.Get<UnitDeathState>();
+                deathState.State = DeathState.Dying;
             }
             battle.FrontlineDamage[party] = damage;
         }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/DestroyDeadUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/DestroyDeadUnitsSystem.cs
@@ -1,0 +1,30 @@
+using Arch.Buffer;
+using Arch.Core;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, BeforeStructuralChanges]
+[ReadCurr(typeof(UnitDeathState)), ChangeStructure]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class DestroyDeadUnitsSystem(World world) : ICalcSystemWithStructuralChanges
+{
+    [Query]
+    [All<UnitDeathState>]
+    private void DestroyDead(
+        Entity entity,
+        ref UnitDeathState deathState,
+        [Data] CommandBuffer commandBuffer
+    )
+    {
+        if (deathState.State != DeathState.Dead)
+            return;
+
+        commandBuffer.Destroy(entity);
+    }
+
+    public void Update(CommandBuffer commandBuffer) => DestroyDeadQuery(world, commandBuffer);
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/PlayUnitDeathEffectSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/PlayUnitDeathEffectSystem.cs
@@ -1,0 +1,54 @@
+using Arch.Buffer;
+using Arch.Core;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Concepts;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, BeforeStructuralChanges]
+[
+    ReadPrev(typeof(AbsoluteTransform)),
+    ReadPrev(typeof(Sprite)),
+    Iterate(typeof(UnitDeathState)),
+    ChangeStructure
+]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class PlayUnitDeathEffectSystem(World world, IConceptFactory factory)
+    : ICalcSystemWithStructuralChanges
+{
+    [Query]
+    [All<UnitDeathState, AbsoluteTransform, Sprite>]
+    private void PlayEffect(
+        ref UnitDeathState deathState,
+        in AbsoluteTransform transform,
+        in Sprite sprite,
+        [Data] CommandBuffer commandBuffer
+    )
+    {
+        if (deathState.State != DeathState.Dying)
+            return;
+
+        var position = transform.Translation;
+        var color = sprite.Color;
+
+        factory.Make(
+            world,
+            commandBuffer,
+            new UnitFlareDescription { Color = color, Position = position }
+        );
+
+        factory.Make(
+            world,
+            commandBuffer,
+            new UnitPulseDescription { Color = color, Position = position }
+        );
+
+        deathState.State = DeathState.Dead;
+    }
+
+    public void Update(CommandBuffer commandBuffer) => PlayEffectQuery(world, commandBuffer);
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/ShootShippingUnitsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/ShootShippingUnitsSystem.cs
@@ -95,24 +95,8 @@ public sealed partial class ShootShippingUnitsSystem(World world, IConceptFactor
             );
         }
 
-        var targetParty = target.Value.Get<InParty.AsAffiliate>().Relationship!.Value.Copy.Party;
-        var targetColor = targetParty.Get<PartyReferenceColor>().Value;
-
-        // 生成闪光
-        factory.Make(
-            world,
-            commandBuffer,
-            new UnitFlareDescription() { Color = targetColor, Position = targetPosition }
-        );
-
-        // 生成冲击波
-        factory.Make(
-            world,
-            commandBuffer,
-            new UnitPulseDescription() { Color = targetColor, Position = targetPosition }
-        );
-
-        commandBuffer.Destroy(target.Value);
+        ref var targetDeathState = ref target.Value.Get<UnitDeathState>();
+        targetDeathState.State = DeathState.Dying;
     }
 
     public void Update(CommandBuffer commandBuffer) => ShootQuery(world, commandBuffer);


### PR DESCRIPTION
- 单位可能在同一帧内被多次选中击杀并分别调用 `Destroy`，导致重复销毁和重复生成死亡动画。
- 将实体的“死亡”状态与“销毁”动作分离。攻击系统将实体标记为“死亡”，但不再负责实体的“销毁”。

Close #57