### PR TITLE
feat(input,render): 选择圈消失时播放淡出动画

### DIFF
--- a/OpenSolarMax.Mods.Core/Components/PlanetSelectionRing.cs
+++ b/OpenSolarMax.Mods.Core/Components/PlanetSelectionRing.cs
@@ -1,0 +1,23 @@
+using Arch.Core;
+using OpenSolarMax.Mods.Core.SourceGenerators;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 星球与选择圈的一对一关系。一个星球可以有多个选择圈（多视图场景），一个选择圈只属于一个星球。
+/// </summary>
+[Relationship]
+public readonly partial struct PlanetSelectionRing(Entity planet, Entity ring)
+{
+    /// <summary>
+    /// 星球实体。非独占：一个星球可以被多个视图选中，因此可以有多个选择圈。
+    /// </summary>
+    [Participant(exclusive: false)]
+    public readonly Entity Planet = planet;
+
+    /// <summary>
+    /// 选择圈实体。独占：一个选择圈只属于一个星球。
+    /// </summary>
+    [Participant]
+    public readonly Entity Ring = ring;
+}

--- a/OpenSolarMax.Mods.Core/Components/SelectionRingVisual.cs
+++ b/OpenSolarMax.Mods.Core/Components/SelectionRingVisual.cs
@@ -1,0 +1,20 @@
+using OpenSolarMax.Game.Modding.ECS;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 选择圈的视觉效果状态。由动画系统驱动 Alpha 和 Scale，渲染系统从 configs 读取颜色和粗细。
+/// </summary>
+[Component]
+public struct SelectionRingVisual()
+{
+    /// <summary>
+    /// 透明度，由动画驱动。初始为 1（完全可见），淡出动画后变为 0（隐藏）。
+    /// </summary>
+    public float Alpha = 1f;
+
+    /// <summary>
+    /// 缩放因子，由动画驱动。初始为 1（正常大小），淡出动画时可增大或减小。
+    /// </summary>
+    public float Scale = 1f;
+}

--- a/OpenSolarMax.Mods.Core/Components/ViewSelectionRing.cs
+++ b/OpenSolarMax.Mods.Core/Components/ViewSelectionRing.cs
@@ -1,0 +1,23 @@
+using Arch.Core;
+using OpenSolarMax.Mods.Core.SourceGenerators;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 视图与选择圈的一对一关系。一个视图可以有多个选择圈（选中多个星球），一个选择圈只属于一个视图。
+/// </summary>
+[Relationship]
+public readonly partial struct ViewSelectionRing(Entity view, Entity ring)
+{
+    /// <summary>
+    /// 视图实体。非独占：一个视图可以选中多个星球，因此可以有多个选择圈。
+    /// </summary>
+    [Participant(exclusive: false)]
+    public readonly Entity View = view;
+
+    /// <summary>
+    /// 选择圈实体。独占：一个选择圈只属于一个视图。
+    /// </summary>
+    [Participant]
+    public readonly Entity Ring = ring;
+}

--- a/OpenSolarMax.Mods.Core/Concepts/Basic/CelestialBody.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Basic/CelestialBody.cs
@@ -44,6 +44,8 @@ public abstract class CelestialBodyDefinition : IDefinition
             // 其他
             typeof(ReferenceSize), // 参考尺寸，用于计算输入和可视化相关
             typeof(TreeRelationship<ColorSync>.AsParent), // 颜色同步关系父方
+            // 选择圈相关
+            typeof(PlanetSelectionRing.AsPlanet), // 星球的选择圈索引
             // AI 相关
             typeof(PlanetAiTimers) // AI 操作计时器
         );

--- a/OpenSolarMax.Mods.Core/Concepts/SelectionRing.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/SelectionRing.cs
@@ -1,0 +1,139 @@
+using Arch.Buffer;
+using Arch.Core;
+using OpenSolarMax.Game.Modding;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Concepts;
+
+public static partial class ConceptNames
+{
+    /// <summary>
+    /// 选择圈概念名称。用于在运行时创建选择圈实体。
+    /// </summary>
+    public const string SelectionRing = "SelectionRing";
+}
+
+/// <summary>
+/// 选择圈实体定义。选择圈是 View 和 Planet 的交叉实体，用于可视化选择状态。
+/// </summary>
+[Define(ConceptNames.SelectionRing)]
+public abstract class SelectionRingDefinition : IDefinition
+{
+    /// <summary>
+    /// 选择圈实体的组件签名。
+    /// </summary>
+    public static Signature Signature { get; } = Signatures.SelectionRing;
+}
+
+/// <summary>
+/// 选择圈实体描述。包含关联的 Planet 和 View 实体引用。
+/// </summary>
+[Describe(ConceptNames.SelectionRing)]
+public class SelectionRingDescription : IDescription
+{
+    /// <summary>
+    /// 关联的星球实体。
+    /// </summary>
+    public required Entity Planet { get; set; }
+
+    /// <summary>
+    /// 关联的视图实体。
+    /// </summary>
+    public required Entity View { get; set; }
+}
+
+/// <summary>
+/// 选择圈实体应用器。创建选择圈实体并建立两个关系（Planet-SelectionRing 和 View-SelectionRing）。
+/// </summary>
+[Apply(ConceptNames.SelectionRing)]
+public class SelectionRingApplier(IConceptFactory factory) : IApplier<SelectionRingDescription>
+{
+    public void Apply(CommandBuffer commandBuffer, Entity entity, SelectionRingDescription desc)
+    {
+        // 设置选择圈的初始视觉状态（选中状态，Alpha=1）
+        commandBuffer.Set(in entity, new SelectionRingVisual() { Alpha = 1, Scale = 1 });
+
+        // 创建 Planet-SelectionRing 关系实体
+        var planetRingDesc = new PlanetSelectionRingDescription()
+        {
+            Planet = desc.Planet,
+            Ring = entity,
+        };
+        factory.Make(
+            World.Worlds[entity.WorldId],
+            commandBuffer,
+            ConceptNames.PlanetSelectionRing,
+            planetRingDesc
+        );
+
+        // 创建 View-SelectionRing 关系实体
+        var viewRingDesc = new ViewSelectionRingDescription() { View = desc.View, Ring = entity };
+        factory.Make(
+            World.Worlds[entity.WorldId],
+            commandBuffer,
+            ConceptNames.ViewSelectionRing,
+            viewRingDesc
+        );
+    }
+}
+
+// 行星-选择圈关系概念
+public static partial class ConceptNames
+{
+    public const string PlanetSelectionRing = "PlanetSelectionRing";
+}
+
+[Define(ConceptNames.PlanetSelectionRing)]
+public abstract class PlanetSelectionRingDefinition : IDefinition
+{
+    public static Signature Signature { get; } = new(typeof(PlanetSelectionRing));
+}
+
+[Describe(ConceptNames.PlanetSelectionRing)]
+public class PlanetSelectionRingDescription : IDescription
+{
+    public required Entity Planet { get; set; }
+    public required Entity Ring { get; set; }
+}
+
+[Apply(ConceptNames.PlanetSelectionRing)]
+public class PlanetSelectionRingApplier : IApplier<PlanetSelectionRingDescription>
+{
+    public void Apply(
+        CommandBuffer commandBuffer,
+        Entity entity,
+        PlanetSelectionRingDescription desc
+    )
+    {
+        commandBuffer.Set(in entity, new PlanetSelectionRing(desc.Planet, desc.Ring));
+    }
+}
+
+// 视图-选择圈关系概念
+public static partial class ConceptNames
+{
+    public const string ViewSelectionRing = "ViewSelectionRing";
+}
+
+[Define(ConceptNames.ViewSelectionRing)]
+public abstract class ViewSelectionRingDefinition : IDefinition
+{
+    public static Signature Signature { get; } = new(typeof(ViewSelectionRing));
+}
+
+[Describe(ConceptNames.ViewSelectionRing)]
+public class ViewSelectionRingDescription : IDescription
+{
+    public required Entity View { get; set; }
+    public required Entity Ring { get; set; }
+}
+
+[Apply(ConceptNames.ViewSelectionRing)]
+public class ViewSelectionRingApplier : IApplier<ViewSelectionRingDescription>
+{
+    public void Apply(CommandBuffer commandBuffer, Entity entity, ViewSelectionRingDescription desc)
+    {
+        commandBuffer.Set(in entity, new ViewSelectionRing(desc.View, desc.Ring));
+    }
+}

--- a/OpenSolarMax.Mods.Core/Concepts/View.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/View.cs
@@ -35,6 +35,8 @@ public abstract class ViewDefinition : IDefinition
             typeof(RenderSettings),
             //
             typeof(InTeam.AsAffiliate),
+            // 选择圈相关
+            typeof(ViewSelectionRing.AsView), // 视图的选择圈索引
             // UI 插件
             typeof(TotalPopulationWidget),
             typeof(FleetSliderWidget),

--- a/OpenSolarMax.Mods.Core/Content/Animations/SelectionRingFadeOut.json
+++ b/OpenSolarMax.Mods.Core/Content/Animations/SelectionRingFadeOut.json
@@ -1,0 +1,13 @@
+{
+    "duration": 0.25,
+    "curves": {
+        "SelectionRingVisual::Alpha": [
+            { "time": 0, "value": 1 },
+            { "time": 0.25, "value": 0 }
+        ],
+        "SelectionRingVisual::Scale": [
+            { "time": 0, "value": 1 },
+            { "time": 0.25, "value": 1.2 }
+        ]
+    }
+}

--- a/OpenSolarMax.Mods.Core/Content/Animations/SelectionRingShrinkFadeOut.json
+++ b/OpenSolarMax.Mods.Core/Content/Animations/SelectionRingShrinkFadeOut.json
@@ -1,0 +1,13 @@
+{
+    "duration": 0.25,
+    "curves": {
+        "SelectionRingVisual::Alpha": [
+            { "time": 0, "value": 1 },
+            { "time": 0.25, "value": 0 }
+        ],
+        "SelectionRingVisual::Scale": [
+            { "time": 0, "value": 1 },
+            { "time": 0.25, "value": 0.8 }
+        ]
+    }
+}

--- a/OpenSolarMax.Mods.Core/Signatures.cs
+++ b/OpenSolarMax.Mods.Core/Signatures.cs
@@ -31,7 +31,8 @@ public static class Signatures
             typeof(ReferenceSize),
             typeof(Battlefield),
             typeof(Animation),
-            typeof(Colonizable)
+            typeof(Colonizable),
+            typeof(PlanetSelectionRing.AsPlanet)
         );
 
     public static readonly Signature Ship =
@@ -81,7 +82,8 @@ public static class Signatures
             typeof(ManeuveringShipsStatus),
             typeof(InTeam.AsAffiliate),
             // typeof(LevelUIContext),
-            typeof(FMOD.Studio.System)
+            typeof(FMOD.Studio.System),
+            typeof(ViewSelectionRing.AsView)
         );
 
     public static readonly Signature Animation =
@@ -104,4 +106,15 @@ public static class Signatures
             typeof(Animation),
             typeof(ExpireAfterAnimationCompleted)
         );
+
+    /// <summary>
+    /// 选择圈实体签名。选择圈不需要位置组件（位置从关联的星球获取）。
+    /// </summary>
+    public static readonly Signature SelectionRing = new(
+        typeof(SelectionRingVisual),
+        typeof(Animation),
+        typeof(ExpireAfterAnimationCompleted),
+        typeof(PlanetSelectionRing.AsRing),
+        typeof(ViewSelectionRing.AsRing)
+    );
 }

--- a/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
@@ -27,8 +27,6 @@ namespace OpenSolarMax.Mods.Core.Systems;
     ReadCurr(typeof(ReachabilityRegistry)),
     ReadCurr(typeof(Projection)),
     Iterate(typeof(JumpingStatus)),
-    ReadCurr(typeof(PlanetSelectionRing.AsRing)),
-    ReadCurr(typeof(ViewSelectionRing.AsRing)),
     ChangeStructure
 ]
 public sealed partial class HandleInputsOnManeuveringShipsSystem(
@@ -49,33 +47,11 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     );
 
     /// <summary>
-    /// 获取某个星球在某个视图的选择圈实体。
+    /// 为某个星球在某个视图创建选择圈实体，返回创建的实体。
     /// </summary>
-    private Entity? GetSelectionRingForPlanet(Entity view, Entity planet)
+    private Entity CreateSelectionRing(Entity view, Entity planet, CommandBuffer commandBuffer)
     {
-        if (!planet.Has<PlanetSelectionRing.AsPlanet>())
-            return null;
-
-        foreach (var (_, record) in planet.Get<PlanetSelectionRing.AsPlanet>().Relationships)
-        {
-            var ring = record.Ring;
-            if (
-                ring.Has<ViewSelectionRing.AsRing>()
-                && ring.Get<ViewSelectionRing.AsRing>().Relationship?.Copy.View == view
-            )
-            {
-                return ring;
-            }
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// 为某个星球在某个视图创建选择圈实体。
-    /// </summary>
-    private void CreateSelectionRing(Entity view, Entity planet, CommandBuffer commandBuffer)
-    {
-        factory.Make(
+        return factory.Make(
             world,
             commandBuffer,
             ConceptNames.SelectionRing,
@@ -93,38 +69,18 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     }
 
     /// <summary>
-    /// 直接销毁选择圈实体。
+    /// 为所有被选中的星球创建选择圈实体并设置淡出动画（用于吸附松开和右键发送飞船）。
     /// </summary>
-    private void DestroySelectionRing(Entity ring, CommandBuffer commandBuffer)
+    private void CreateAndFadeOutSelectionRings(
+        Entity view,
+        IEnumerable<Entity> planets,
+        CommandBuffer commandBuffer
+    )
     {
-        commandBuffer.Destroy(ring);
-    }
-
-    /// <summary>
-    /// 为视图的所有选择圈设置淡出动画（用于吸附松开和右键发送飞船）。
-    /// </summary>
-    private void FadeOutAllSelectionRings(Entity view, CommandBuffer commandBuffer)
-    {
-        if (!view.Has<ViewSelectionRing.AsView>())
-            return;
-
-        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
+        foreach (var planet in planets)
         {
-            SetFadeOutAnimation(record.Ring, commandBuffer);
-        }
-    }
-
-    /// <summary>
-    /// 销毁视图的所有选择圈（用于悬空松开）。
-    /// </summary>
-    private void DestroyAllSelectionRings(Entity view, CommandBuffer commandBuffer)
-    {
-        if (!view.Has<ViewSelectionRing.AsView>())
-            return;
-
-        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
-        {
-            DestroySelectionRing(record.Ring, commandBuffer);
+            var ring = CreateSelectionRing(view, planet, commandBuffer);
+            SetFadeOutAnimation(ring, commandBuffer);
         }
     }
 
@@ -291,8 +247,12 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                         }
                     );
                 }
-                // 右键发送飞船后，给所有选择圈设置淡出动画
-                FadeOutAllSelectionRings(view, commandBuffer);
+                // 右键发送飞船后，为所有被选中的星球创建选择圈实体并设置淡出动画
+                CreateAndFadeOutSelectionRings(
+                    view,
+                    selection.SimpleSelecting.SelectedSources,
+                    commandBuffer
+                );
                 selection.State = ShipsSelection_State.SimpleSelecting;
                 selection.SimpleSelecting = new() { SelectedSources = [] };
             }
@@ -358,28 +318,29 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                             }
                         );
                     }
-                    // 吸附松开后，给所有选择圈设置淡出动画
-                    FadeOutAllSelectionRings(view, commandBuffer);
+                    // 吸附松开后，为所有被选中的星球创建选择圈实体并设置淡出动画
+                    CreateAndFadeOutSelectionRings(
+                        view,
+                        selection.DraggingToDestination.SelectedSources,
+                        commandBuffer
+                    );
                     selection.SimpleSelecting = new() { SelectedSources = [] };
                 }
                 else
-                {
-                    // 悬空松开后，直接销毁所有选择圈（原版 S2 行为）
-                    DestroyAllSelectionRings(view, commandBuffer);
-                    selection.SimpleSelecting = new() { SelectedSources = [] };
-                }
+                    selection.SimpleSelecting = new()
+                    {
+                        SelectedSources = selection.DraggingToDestination.SelectedSources,
+                    };
             }
         }
     }
 
     private void UpdateSelectionStatus(
-        Entity view, // View 实体
         ref ShipsSelection selection,
         in Matrix worldToScreen,
         Entity team,
         ref Entity? pointedPlanet,
-        in InputFocusState focus,
-        CommandBuffer commandBuffer
+        in InputFocusState focus
     )
     {
         var mouse = Mouse.GetState();
@@ -404,15 +365,8 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                 if (_lastLeftButton == ButtonState.Released && tappingSource != Entity.Null)
                 {
                     if (keys[Keys.LeftShift] != KeyState.Down)
-                    {
-                        // 清空之前的选中，需要先给所有选择圈设置淡出动画
-                        FadeOutAllSelectionRings(view, commandBuffer);
                         selection.SimpleSelecting.SelectedSources.Clear();
-                    }
                     selection.SimpleSelecting.SelectedSources.Add(tappingSource);
-                    // 为新选中的星球创建选择圈（如果该星球还没有属于当前视图的选择圈）
-                    if (GetSelectionRingForPlanet(view, tappingSource) == null)
-                        CreateSelectionRing(view, tappingSource, commandBuffer);
                 }
             }
             else
@@ -491,13 +445,11 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
             in focus
         );
         UpdateSelectionStatus(
-            entity, // 传入 View 实体
             ref status.Selection,
             in projection.WorldToScreen,
             ofTeam.Relationship!.Value.Copy.Team,
             ref pointedPlanet,
-            in focus,
-            commandBuffer
+            in focus
         );
         _lastLeftButton = Mouse.GetState().LeftButton;
     }

--- a/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
@@ -39,11 +39,12 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     private readonly int _minimalSelectPixels = configs.RequireValue<int>("minimal_select_pixels");
     private ButtonState _lastLeftButton = ButtonState.Released;
 
-    /// <summary>
-    /// 淡出动画剪辑，用于选择圈消失时的动画。
-    /// </summary>
-    private readonly AnimationClip<Entity> _fadeOutClip = assets.Load<AnimationClip<Entity>>(
+    private readonly AnimationClip<Entity> _growFadeClip = assets.Load<AnimationClip<Entity>>(
         "/Animations/SelectionRingFadeOut.json"
+    );
+
+    private readonly AnimationClip<Entity> _shrinkFadeClip = assets.Load<AnimationClip<Entity>>(
+        "/Animations/SelectionRingShrinkFadeOut.json"
     );
 
     /// <summary>
@@ -59,18 +60,15 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
         );
     }
 
-    /// <summary>
-    /// 为选择圈设置淡出动画。
-    /// </summary>
-    private void SetFadeOutAnimation(Entity ring, CommandBuffer commandBuffer)
+    private void SetFadeAnimation(
+        Entity ring,
+        AnimationClip<Entity> clip,
+        CommandBuffer commandBuffer
+    )
     {
-        // 重置动画状态并设置淡出剪辑，播完后由 ExpireAnimationCompletedEntitiesSystem 自动销毁
-        commandBuffer.Set(in ring, new Animation() { Clip = _fadeOutClip });
+        commandBuffer.Set(in ring, new Animation() { Clip = clip });
     }
 
-    /// <summary>
-    /// 为所有被选中的星球创建选择圈实体并设置淡出动画（用于吸附松开和右键发送飞船）。
-    /// </summary>
     private void CreateAndFadeOutSelectionRings(
         Entity view,
         IEnumerable<Entity> planets,
@@ -80,7 +78,7 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
         foreach (var planet in planets)
         {
             var ring = CreateSelectionRing(view, planet, commandBuffer);
-            SetFadeOutAnimation(ring, commandBuffer);
+            SetFadeAnimation(ring, _growFadeClip, commandBuffer);
         }
     }
 
@@ -247,12 +245,18 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                         }
                     );
                 }
-                // 右键发送飞船后，为所有被选中的星球创建选择圈实体并设置淡出动画
+                // 右键发送飞船后，为出发星球创建扩散式淡出，为目标星球创建收缩式淡出
                 CreateAndFadeOutSelectionRings(
                     view,
                     selection.SimpleSelecting.SelectedSources,
                     commandBuffer
                 );
+                var destinationRing = CreateSelectionRing(
+                    view,
+                    selection.SimpleSelecting.TappingDestination,
+                    commandBuffer
+                );
+                SetFadeAnimation(destinationRing, _shrinkFadeClip, commandBuffer);
                 selection.State = ShipsSelection_State.SimpleSelecting;
                 selection.SimpleSelecting = new() { SelectedSources = [] };
             }
@@ -318,12 +322,18 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                             }
                         );
                     }
-                    // 吸附松开后，为所有被选中的星球创建选择圈实体并设置淡出动画
+                    // 吸附松开后，为出发星球创建扩散式淡出，为目标星球创建收缩式淡出
                     CreateAndFadeOutSelectionRings(
                         view,
                         selection.DraggingToDestination.SelectedSources,
                         commandBuffer
                     );
+                    var destinationRing = CreateSelectionRing(
+                        view,
+                        selection.DraggingToDestination.CandidateDestination,
+                        commandBuffer
+                    );
+                    SetFadeAnimation(destinationRing, _shrinkFadeClip, commandBuffer);
                     selection.SimpleSelecting = new() { SelectedSources = [] };
                 }
                 else

--- a/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
@@ -202,6 +202,12 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                     else if (_lastLeftButton == ButtonState.Released)
                     {
                         // 当前左键点在空白处，而且之前也没有正在点选任何星球，则切换至框选状态
+                        if (!keepPrevious)
+                            CreateAndFadeOutSelectionRings(
+                                view,
+                                selection.SimpleSelecting.SelectedSources,
+                                commandBuffer
+                            );
                         selection.State = ShipsSelection_State.BoxSelectingSources;
                         selection.BoxSelectingSources = new()
                         {
@@ -346,11 +352,13 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     }
 
     private void UpdateSelectionStatus(
+        Entity view,
         ref ShipsSelection selection,
         in Matrix worldToScreen,
         Entity team,
         ref Entity? pointedPlanet,
-        in InputFocusState focus
+        in InputFocusState focus,
+        CommandBuffer commandBuffer
     )
     {
         var mouse = Mouse.GetState();
@@ -375,7 +383,14 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                 if (_lastLeftButton == ButtonState.Released && tappingSource != Entity.Null)
                 {
                     if (keys[Keys.LeftShift] != KeyState.Down)
+                    {
+                        CreateAndFadeOutSelectionRings(
+                            view,
+                            selection.SimpleSelecting.SelectedSources,
+                            commandBuffer
+                        );
                         selection.SimpleSelecting.SelectedSources.Clear();
+                    }
                     selection.SimpleSelecting.SelectedSources.Add(tappingSource);
                 }
             }
@@ -455,11 +470,13 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
             in focus
         );
         UpdateSelectionStatus(
+            entity,
             ref status.Selection,
             in projection.WorldToScreen,
             ofTeam.Relationship!.Value.Copy.Team,
             ref pointedPlanet,
-            in focus
+            in focus,
+            commandBuffer
         );
         _lastLeftButton = Mouse.GetState().LeftButton;
     }

--- a/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Input/HandleInputsOnManeuveringShipsSystem.cs
@@ -7,6 +7,8 @@ using Arch.System.SourceGenerator;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Nine.Animations;
+using Nine.Assets;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
@@ -25,16 +27,106 @@ namespace OpenSolarMax.Mods.Core.Systems;
     ReadCurr(typeof(ReachabilityRegistry)),
     ReadCurr(typeof(Projection)),
     Iterate(typeof(JumpingStatus)),
+    ReadCurr(typeof(PlanetSelectionRing.AsRing)),
+    ReadCurr(typeof(ViewSelectionRing.AsRing)),
     ChangeStructure
 ]
 public sealed partial class HandleInputsOnManeuveringShipsSystem(
     World world,
     IConceptFactory factory,
+    IAssetsManager assets,
     [Section("systems:input:maneuvering")] IConfiguration configs
 ) : ICalcSystemWithStructuralChanges
 {
     private readonly int _minimalSelectPixels = configs.RequireValue<int>("minimal_select_pixels");
     private ButtonState _lastLeftButton = ButtonState.Released;
+
+    /// <summary>
+    /// 淡出动画剪辑，用于选择圈消失时的动画。
+    /// </summary>
+    private readonly AnimationClip<Entity> _fadeOutClip = assets.Load<AnimationClip<Entity>>(
+        "/Animations/SelectionRingFadeOut.json"
+    );
+
+    /// <summary>
+    /// 获取某个星球在某个视图的选择圈实体。
+    /// </summary>
+    private Entity? GetSelectionRingForPlanet(Entity view, Entity planet)
+    {
+        if (!planet.Has<PlanetSelectionRing.AsPlanet>())
+            return null;
+
+        foreach (var (_, record) in planet.Get<PlanetSelectionRing.AsPlanet>().Relationships)
+        {
+            var ring = record.Ring;
+            if (
+                ring.Has<ViewSelectionRing.AsRing>()
+                && ring.Get<ViewSelectionRing.AsRing>().Relationship?.Copy.View == view
+            )
+            {
+                return ring;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 为某个星球在某个视图创建选择圈实体。
+    /// </summary>
+    private void CreateSelectionRing(Entity view, Entity planet, CommandBuffer commandBuffer)
+    {
+        factory.Make(
+            world,
+            commandBuffer,
+            ConceptNames.SelectionRing,
+            new SelectionRingDescription() { Planet = planet, View = view }
+        );
+    }
+
+    /// <summary>
+    /// 为选择圈设置淡出动画。
+    /// </summary>
+    private void SetFadeOutAnimation(Entity ring, CommandBuffer commandBuffer)
+    {
+        // 重置动画状态并设置淡出剪辑，播完后由 ExpireAnimationCompletedEntitiesSystem 自动销毁
+        commandBuffer.Set(in ring, new Animation() { Clip = _fadeOutClip });
+    }
+
+    /// <summary>
+    /// 直接销毁选择圈实体。
+    /// </summary>
+    private void DestroySelectionRing(Entity ring, CommandBuffer commandBuffer)
+    {
+        commandBuffer.Destroy(ring);
+    }
+
+    /// <summary>
+    /// 为视图的所有选择圈设置淡出动画（用于吸附松开和右键发送飞船）。
+    /// </summary>
+    private void FadeOutAllSelectionRings(Entity view, CommandBuffer commandBuffer)
+    {
+        if (!view.Has<ViewSelectionRing.AsView>())
+            return;
+
+        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
+        {
+            SetFadeOutAnimation(record.Ring, commandBuffer);
+        }
+    }
+
+    /// <summary>
+    /// 销毁视图的所有选择圈（用于悬空松开）。
+    /// </summary>
+    private void DestroyAllSelectionRings(Entity view, CommandBuffer commandBuffer)
+    {
+        if (!view.Has<ViewSelectionRing.AsView>())
+            return;
+
+        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
+        {
+            DestroySelectionRing(record.Ring, commandBuffer);
+        }
+    }
 
     [Query]
     [All<TreeRelationship<Anchorage>.AsParent, AbsoluteTransform>]
@@ -114,6 +206,7 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     }
 
     private void HandleSelectionStateTransition(
+        Entity view, // View 实体
         ref ShipsSelection selection,
         float percentage,
         in Matrix worldToScreen,
@@ -198,6 +291,8 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                         }
                     );
                 }
+                // 右键发送飞船后，给所有选择圈设置淡出动画
+                FadeOutAllSelectionRings(view, commandBuffer);
                 selection.State = ShipsSelection_State.SimpleSelecting;
                 selection.SimpleSelecting = new() { SelectedSources = [] };
             }
@@ -263,23 +358,28 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                             }
                         );
                     }
+                    // 吸附松开后，给所有选择圈设置淡出动画
+                    FadeOutAllSelectionRings(view, commandBuffer);
                     selection.SimpleSelecting = new() { SelectedSources = [] };
                 }
                 else
-                    selection.SimpleSelecting = new()
-                    {
-                        SelectedSources = selection.DraggingToDestination.SelectedSources,
-                    };
+                {
+                    // 悬空松开后，直接销毁所有选择圈（原版 S2 行为）
+                    DestroyAllSelectionRings(view, commandBuffer);
+                    selection.SimpleSelecting = new() { SelectedSources = [] };
+                }
             }
         }
     }
 
     private void UpdateSelectionStatus(
+        Entity view, // View 实体
         ref ShipsSelection selection,
         in Matrix worldToScreen,
         Entity team,
         ref Entity? pointedPlanet,
-        in InputFocusState focus
+        in InputFocusState focus,
+        CommandBuffer commandBuffer
     )
     {
         var mouse = Mouse.GetState();
@@ -304,8 +404,15 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
                 if (_lastLeftButton == ButtonState.Released && tappingSource != Entity.Null)
                 {
                     if (keys[Keys.LeftShift] != KeyState.Down)
+                    {
+                        // 清空之前的选中，需要先给所有选择圈设置淡出动画
+                        FadeOutAllSelectionRings(view, commandBuffer);
                         selection.SimpleSelecting.SelectedSources.Clear();
+                    }
                     selection.SimpleSelecting.SelectedSources.Add(tappingSource);
+                    // 为新选中的星球创建选择圈（如果该星球还没有属于当前视图的选择圈）
+                    if (GetSelectionRingForPlanet(view, tappingSource) == null)
+                        CreateSelectionRing(view, tappingSource, commandBuffer);
                 }
             }
             else
@@ -363,6 +470,7 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
         InputFocusState
     >]
     private void HandleInputs(
+        Entity entity, // View 实体
         ref ManeuveringShipsStatus status,
         in FleetSliderWidget fleetSlider,
         in InTeam.AsAffiliate ofTeam,
@@ -373,6 +481,7 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
     {
         Entity? pointedPlanet = null;
         HandleSelectionStateTransition(
+            entity, // 传入 View 实体
             ref status.Selection,
             fleetSlider.Percentage,
             in projection.WorldToScreen,
@@ -382,11 +491,13 @@ public sealed partial class HandleInputsOnManeuveringShipsSystem(
             in focus
         );
         UpdateSelectionStatus(
+            entity, // 传入 View 实体
             ref status.Selection,
             in projection.WorldToScreen,
             ofTeam.Relationship!.Value.Copy.Team,
             ref pointedPlanet,
-            in focus
+            in focus,
+            commandBuffer
         );
         _lastLeftButton = Mouse.GetState().LeftButton;
     }

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
@@ -28,7 +28,10 @@ public delegate bool? CheckLocationReachabilityCallback(
     ReadCurr(typeof(AbsoluteTransform)),
     ReadCurr(typeof(ReferenceSize)),
     ReadCurr(typeof(ManeuveringShipsStatus)),
-    ReadCurr(typeof(Projection))
+    ReadCurr(typeof(Projection)),
+    ReadCurr(typeof(SelectionRingVisual)),
+    ReadCurr(typeof(PlanetSelectionRing.AsRing)),
+    ReadCurr(typeof(ViewSelectionRing.AsRing))
 ]
 public sealed partial class VisualizeManeuveringShipsStatusSystem(
     World world,
@@ -60,6 +63,65 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
     public CheckLocationReachabilityCallback? CheckReachabilityDelegate { get; set; }
 
     public void Update() => DrawSelectionQuery(world);
+
+    /// <summary>
+    /// 绘制视图的所有选择圈实体。
+    /// </summary>
+    private void DrawSelectionRings(Entity view, in Projection projection)
+    {
+        if (!view.Has<ViewSelectionRing.AsView>())
+            return;
+
+        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
+        {
+            var ring = record.Ring;
+
+            // 获取选择圈的视觉状态
+            if (!ring.Has<SelectionRingVisual>())
+                continue;
+
+            var visual = ring.Get<SelectionRingVisual>();
+            if (visual.Alpha <= 0)
+                continue; // Alpha 为 0 时不绘制
+
+            // 获取关联的星球实体
+            if (!ring.Has<PlanetSelectionRing.AsRing>())
+                continue;
+
+            var planetRecord = ring.Get<PlanetSelectionRing.AsRing>().Relationship;
+            if (planetRecord == null)
+                continue;
+
+            var planet = planetRecord.Value.Copy.Planet;
+            if (
+                !planet.IsAlive()
+                || !planet.Has<ReferenceSize>()
+                || !planet.Has<AbsoluteTransform>()
+            )
+                continue;
+
+            // 获取星球的位置和参考尺寸
+            var planetCompos = planet.Get<ReferenceSize, AbsoluteTransform>();
+            ref readonly var refSize = ref planetCompos.t0;
+            ref readonly var pose = ref planetCompos.t1;
+
+            // 计算选择环的尺寸（考虑 Scale 和屏幕缩放）
+            var scale2D = Vector2.TransformNormal(Vector2.One, projection.WorldToScreen);
+            var screenScale = MathF.Abs(MathF.MaxMagnitude(scale2D.X, scale2D.Y));
+            var ringRadius = refSize.Radius * _ringRadiusFactor * visual.Scale * screenScale;
+
+            // 计算选择环的位置
+            var ringInScreen = TransformProjection.To2D(
+                Vector3.Transform(pose.Translation, projection.WorldToScreen)
+            );
+
+            // 计算颜色（考虑 Alpha）
+            var color = _selectedRingColor * visual.Alpha;
+
+            // 绘制选择环
+            _circleRenderer.DrawCircle(ringInScreen, ringRadius, color, _ringThickness);
+        }
+    }
 
     private void DrawSelected(
         in ReferenceSize refSize,
@@ -234,7 +296,11 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
 
     [Query]
     [All<ManeuveringShipsStatus, Projection>]
-    private void DrawSelection(in ManeuveringShipsStatus status, in Projection projection)
+    private void DrawSelection(
+        Entity entity,
+        in ManeuveringShipsStatus status,
+        in Projection projection
+    )
     {
         var mouse = Mouse.GetState();
 
@@ -254,10 +320,13 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
 
         var mouseInScreen = mouse.Position;
 
-        // 当处于默认状态时，绘制所有点选和正在选的星球
+        // 绘制所有选择圈实体（从选择圈实体绘制，而不是直接从 SelectedSources 绘制）
+        DrawSelectionRings(entity, in projection);
+
+        // 当处于默认状态时，绘制悬停圈和目标圈
         if (selection.State == ShipsSelection_State.SimpleSelecting)
         {
-            // 如果当前没有点选星球，且此时鼠标位于某个星球上，则进行预览
+            // 如果当前没有点选星球，且此时鼠标位于某个星球上，则进行预览（悬停圈）
             if (mouse.LeftButton != ButtonState.Pressed)
             {
                 if (selection.SimpleSelecting.PointingPlanet != Entity.Null)
@@ -269,16 +338,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     );
             }
 
-            // 绘制所有选中的星球
-            // TappingSource已经包含在SelectedSources中了，故不重复绘制
-            DrawSelected(
-                selection.SimpleSelecting.SelectedSources,
-                in projection.WorldToScreen,
-                Enumerable.Repeat(_selectedRingColor, int.MaxValue),
-                _ringThickness
-            );
-
-            // 绘制目标星球
+            // 绘制目标星球（右键目标圈）
             if (selection.SimpleSelecting.TappingDestination != Entity.Null)
                 DrawSelected(
                     selection.SimpleSelecting.TappingDestination,
@@ -287,20 +347,9 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     _ringThickness
                 );
         }
-        // 当处于框选状态时，还需要绘制选框和选框内的星球
+        // 当处于框选状态时，绘制选框
         else if (selection.State == ShipsSelection_State.BoxSelectingSources)
         {
-            // 绘制所有选中的星球
-            DrawSelected(
-                Enumerable.Concat(
-                    selection.BoxSelectingSources.OtherSelectedPlanets,
-                    selection.BoxSelectingSources.PlanetsInBox
-                ),
-                in projection.WorldToScreen,
-                Enumerable.Repeat(_selectedRingColor, int.MaxValue),
-                _ringThickness
-            );
-
             // 绘制选框
             _boxRenderer.DrawBox(
                 selection.BoxSelectingSources.BoxInScreen,
@@ -308,12 +357,9 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                 _boxThickness
             );
         }
-        // 当处于拖拽状态时，还需要绘制起点到目标的线段
+        // 当处于拖拽状态时，绘制拖拽线和目标圈
         else if (selection.State == ShipsSelection_State.DraggingToDestination)
         {
-            // 所有不能抵达目标位置的出发点和边画红色圈
-            // 如果所有出发点都无法到达目标点，则目标点画红色圈
-
             var blockStates =
                 selection.DraggingToDestination.CandidateDestination == Entity.Null
                     ? CalculateBlocking(
@@ -328,14 +374,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                         )
                         .ToArray();
 
-            var sourceColors = blockStates.Select(b => b ? _blockedRingColor : _selectedRingColor);
-            DrawSelected(
-                selection.DraggingToDestination.SelectedSources,
-                in projection.WorldToScreen,
-                sourceColors,
-                _ringThickness
-            );
-
+            // 绘制拖拽线
             var edgeColors = blockStates.Select(b => b ? _blockedLineColor : _lineColor);
             if (selection.DraggingToDestination.CandidateDestination == Entity.Null)
                 DrawLines(
@@ -353,6 +392,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     edgeColors
                 );
 
+                // 绘制目标圈（悬停的目标星球）
                 var targetColor = blockStates.All(b => b) ? _blockedRingColor : _selectedRingColor;
                 DrawSelected(
                     selection.DraggingToDestination.CandidateDestination,

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
@@ -28,7 +28,9 @@ public delegate bool? CheckLocationReachabilityCallback(
     ReadCurr(typeof(AbsoluteTransform)),
     ReadCurr(typeof(ReferenceSize)),
     ReadCurr(typeof(ManeuveringShipsStatus)),
-    ReadCurr(typeof(Projection))
+    ReadCurr(typeof(Projection)),
+    ReadCurr(typeof(SelectionRingVisual)),
+    ReadCurr(typeof(PlanetSelectionRing.AsPlanet))
 ]
 public sealed partial class VisualizeManeuveringShipsStatusSystem(
     World world,
@@ -260,13 +262,39 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
             // 如果当前没有点选星球，且此时鼠标位于某个星球上，则进行预览
             if (mouse.LeftButton != ButtonState.Pressed)
             {
-                if (selection.SimpleSelecting.PointingPlanet != Entity.Null)
-                    DrawSelected(
-                        selection.SimpleSelecting.PointingPlanet,
-                        in projection.WorldToScreen,
-                        _hoveredRingColor,
-                        _ringThickness
-                    );
+                var pointingPlanet = selection.SimpleSelecting.PointingPlanet;
+                if (pointingPlanet != Entity.Null)
+                {
+                    // 检查该星球是否有正在淡出的选择圈实体，如果有则跳过预览圈
+                    var hasFadingRing = false;
+                    if (pointingPlanet.Has<PlanetSelectionRing.AsPlanet>())
+                    {
+                        foreach (
+                            var (_, record) in pointingPlanet
+                                .Get<PlanetSelectionRing.AsPlanet>()
+                                .Relationships
+                        )
+                        {
+                            var ring = record.Ring;
+                            if (
+                                ring.Has<SelectionRingVisual>()
+                                && ring.Get<SelectionRingVisual>().Alpha > 0
+                            )
+                            {
+                                hasFadingRing = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!hasFadingRing)
+                        DrawSelected(
+                            pointingPlanet,
+                            in projection.WorldToScreen,
+                            _hoveredRingColor,
+                            _ringThickness
+                        );
+                }
             }
 
             // 绘制所有选中的星球

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
@@ -28,10 +28,7 @@ public delegate bool? CheckLocationReachabilityCallback(
     ReadCurr(typeof(AbsoluteTransform)),
     ReadCurr(typeof(ReferenceSize)),
     ReadCurr(typeof(ManeuveringShipsStatus)),
-    ReadCurr(typeof(Projection)),
-    ReadCurr(typeof(SelectionRingVisual)),
-    ReadCurr(typeof(PlanetSelectionRing.AsRing)),
-    ReadCurr(typeof(ViewSelectionRing.AsRing))
+    ReadCurr(typeof(Projection))
 ]
 public sealed partial class VisualizeManeuveringShipsStatusSystem(
     World world,
@@ -63,65 +60,6 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
     public CheckLocationReachabilityCallback? CheckReachabilityDelegate { get; set; }
 
     public void Update() => DrawSelectionQuery(world);
-
-    /// <summary>
-    /// 绘制视图的所有选择圈实体。
-    /// </summary>
-    private void DrawSelectionRings(Entity view, in Projection projection)
-    {
-        if (!view.Has<ViewSelectionRing.AsView>())
-            return;
-
-        foreach (var (_, record) in view.Get<ViewSelectionRing.AsView>().Relationships)
-        {
-            var ring = record.Ring;
-
-            // 获取选择圈的视觉状态
-            if (!ring.Has<SelectionRingVisual>())
-                continue;
-
-            var visual = ring.Get<SelectionRingVisual>();
-            if (visual.Alpha <= 0)
-                continue; // Alpha 为 0 时不绘制
-
-            // 获取关联的星球实体
-            if (!ring.Has<PlanetSelectionRing.AsRing>())
-                continue;
-
-            var planetRecord = ring.Get<PlanetSelectionRing.AsRing>().Relationship;
-            if (planetRecord == null)
-                continue;
-
-            var planet = planetRecord.Value.Copy.Planet;
-            if (
-                !planet.IsAlive()
-                || !planet.Has<ReferenceSize>()
-                || !planet.Has<AbsoluteTransform>()
-            )
-                continue;
-
-            // 获取星球的位置和参考尺寸
-            var planetCompos = planet.Get<ReferenceSize, AbsoluteTransform>();
-            ref readonly var refSize = ref planetCompos.t0;
-            ref readonly var pose = ref planetCompos.t1;
-
-            // 计算选择环的尺寸（考虑 Scale 和屏幕缩放）
-            var scale2D = Vector2.TransformNormal(Vector2.One, projection.WorldToScreen);
-            var screenScale = MathF.Abs(MathF.MaxMagnitude(scale2D.X, scale2D.Y));
-            var ringRadius = refSize.Radius * _ringRadiusFactor * visual.Scale * screenScale;
-
-            // 计算选择环的位置
-            var ringInScreen = TransformProjection.To2D(
-                Vector3.Transform(pose.Translation, projection.WorldToScreen)
-            );
-
-            // 计算颜色（考虑 Alpha）
-            var color = _selectedRingColor * visual.Alpha;
-
-            // 绘制选择环
-            _circleRenderer.DrawCircle(ringInScreen, ringRadius, color, _ringThickness);
-        }
-    }
 
     private void DrawSelected(
         in ReferenceSize refSize,
@@ -296,11 +234,7 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
 
     [Query]
     [All<ManeuveringShipsStatus, Projection>]
-    private void DrawSelection(
-        Entity entity,
-        in ManeuveringShipsStatus status,
-        in Projection projection
-    )
+    private void DrawSelection(in ManeuveringShipsStatus status, in Projection projection)
     {
         var mouse = Mouse.GetState();
 
@@ -319,9 +253,6 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
         ref readonly var selection = ref status.Selection;
 
         var mouseInScreen = mouse.Position;
-
-        // 绘制所有选择圈实体（从选择圈实体绘制，而不是直接从 SelectedSources 绘制）
-        DrawSelectionRings(entity, in projection);
 
         // 当处于默认状态时，绘制所有点选和正在选的星球
         if (selection.State == ShipsSelection_State.SimpleSelecting)

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeManeuveringShipsStatusSystem.cs
@@ -323,10 +323,10 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
         // 绘制所有选择圈实体（从选择圈实体绘制，而不是直接从 SelectedSources 绘制）
         DrawSelectionRings(entity, in projection);
 
-        // 当处于默认状态时，绘制悬停圈和目标圈
+        // 当处于默认状态时，绘制所有点选和正在选的星球
         if (selection.State == ShipsSelection_State.SimpleSelecting)
         {
-            // 如果当前没有点选星球，且此时鼠标位于某个星球上，则进行预览（悬停圈）
+            // 如果当前没有点选星球，且此时鼠标位于某个星球上，则进行预览
             if (mouse.LeftButton != ButtonState.Pressed)
             {
                 if (selection.SimpleSelecting.PointingPlanet != Entity.Null)
@@ -338,7 +338,16 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     );
             }
 
-            // 绘制目标星球（右键目标圈）
+            // 绘制所有选中的星球
+            // TappingSource已经包含在SelectedSources中了，故不重复绘制
+            DrawSelected(
+                selection.SimpleSelecting.SelectedSources,
+                in projection.WorldToScreen,
+                Enumerable.Repeat(_selectedRingColor, int.MaxValue),
+                _ringThickness
+            );
+
+            // 绘制目标星球
             if (selection.SimpleSelecting.TappingDestination != Entity.Null)
                 DrawSelected(
                     selection.SimpleSelecting.TappingDestination,
@@ -347,9 +356,20 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     _ringThickness
                 );
         }
-        // 当处于框选状态时，绘制选框
+        // 当处于框选状态时，还需要绘制选框和选框内的星球
         else if (selection.State == ShipsSelection_State.BoxSelectingSources)
         {
+            // 绘制所有选中的星球
+            DrawSelected(
+                Enumerable.Concat(
+                    selection.BoxSelectingSources.OtherSelectedPlanets,
+                    selection.BoxSelectingSources.PlanetsInBox
+                ),
+                in projection.WorldToScreen,
+                Enumerable.Repeat(_selectedRingColor, int.MaxValue),
+                _ringThickness
+            );
+
             // 绘制选框
             _boxRenderer.DrawBox(
                 selection.BoxSelectingSources.BoxInScreen,
@@ -357,9 +377,12 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                 _boxThickness
             );
         }
-        // 当处于拖拽状态时，绘制拖拽线和目标圈
+        // 当处于拖拽状态时，还需要绘制起点到目标的线段
         else if (selection.State == ShipsSelection_State.DraggingToDestination)
         {
+            // 所有不能抵达目标位置的出发点和边画红色圈
+            // 如果所有出发点都无法到达目标点，则目标点画红色圈
+
             var blockStates =
                 selection.DraggingToDestination.CandidateDestination == Entity.Null
                     ? CalculateBlocking(
@@ -374,7 +397,14 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                         )
                         .ToArray();
 
-            // 绘制拖拽线
+            var sourceColors = blockStates.Select(b => b ? _blockedRingColor : _selectedRingColor);
+            DrawSelected(
+                selection.DraggingToDestination.SelectedSources,
+                in projection.WorldToScreen,
+                sourceColors,
+                _ringThickness
+            );
+
             var edgeColors = blockStates.Select(b => b ? _blockedLineColor : _lineColor);
             if (selection.DraggingToDestination.CandidateDestination == Entity.Null)
                 DrawLines(
@@ -392,7 +422,6 @@ public sealed partial class VisualizeManeuveringShipsStatusSystem(
                     edgeColors
                 );
 
-                // 绘制目标圈（悬停的目标星球）
                 var targetColor = blockStates.All(b => b) ? _blockedRingColor : _selectedRingColor;
                 DrawSelected(
                     selection.DraggingToDestination.CandidateDestination,

--- a/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeSelectionRingsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Render/Visualization/VisualizeSelectionRingsSystem.cs
@@ -1,0 +1,99 @@
+using Arch.Core;
+using Arch.Core.Extensions;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using OpenSolarMax.Game.Modding.Configuration;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Graphics;
+using OpenSolarMax.Mods.Core.Utils;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[RenderSystem, AfterStructuralChanges]
+[Priority((int)GraphicsLayer.Interface)]
+[
+    ReadCurr(typeof(AbsoluteTransform)),
+    ReadCurr(typeof(ReferenceSize)),
+    ReadCurr(typeof(Projection)),
+    ReadCurr(typeof(SelectionRingVisual)),
+    ReadCurr(typeof(PlanetSelectionRing.AsRing)),
+    ReadCurr(typeof(ViewSelectionRing.AsRing))
+]
+public sealed partial class VisualizeSelectionRingsSystem(
+    World world,
+    GraphicsDevice graphicsDevice,
+    [Section("systems:visualization:maneuvering_ships_status")] IConfiguration configs
+) : ICalcSystem
+{
+    private readonly float _ringRadiusFactor = configs.RequireValue<float>(
+        "ring:radius_multiplier"
+    );
+    private readonly float _ringThickness = configs.RequireValue<float>("ring:thickness");
+    private readonly Color _selectedRingColor = configs.RequireValue<Color>("ring:selected:color");
+
+    private readonly CircleRenderer _circleRenderer = new(graphicsDevice);
+
+    public void Update() => DrawSelectionRingsQuery(world);
+
+    [Query]
+    [All<Projection>]
+    private void DrawSelectionRings(Entity entity, in Projection projection)
+    {
+        graphicsDevice.BlendState = BlendState.AlphaBlend;
+        graphicsDevice.DepthStencilState = DepthStencilState.None;
+        graphicsDevice.RasterizerState = RasterizerState.CullClockwise;
+        graphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+
+        _circleRenderer.Effect.Projection = projection.ScreenToNdc;
+
+        if (!entity.Has<ViewSelectionRing.AsView>())
+            return;
+
+        foreach (var (_, record) in entity.Get<ViewSelectionRing.AsView>().Relationships)
+        {
+            var ring = record.Ring;
+
+            if (!ring.Has<SelectionRingVisual>())
+                continue;
+
+            var visual = ring.Get<SelectionRingVisual>();
+            if (visual.Alpha <= 0)
+                continue;
+
+            if (!ring.Has<PlanetSelectionRing.AsRing>())
+                continue;
+
+            var planetRecord = ring.Get<PlanetSelectionRing.AsRing>().Relationship;
+            if (planetRecord == null)
+                continue;
+
+            var planet = planetRecord.Value.Copy.Planet;
+            if (
+                !planet.IsAlive()
+                || !planet.Has<ReferenceSize>()
+                || !planet.Has<AbsoluteTransform>()
+            )
+                continue;
+
+            var planetCompos = planet.Get<ReferenceSize, AbsoluteTransform>();
+            ref readonly var refSize = ref planetCompos.t0;
+            ref readonly var pose = ref planetCompos.t1;
+
+            var scale2D = Vector2.TransformNormal(Vector2.One, projection.WorldToScreen);
+            var screenScale = MathF.Abs(MathF.MaxMagnitude(scale2D.X, scale2D.Y));
+            var ringRadius = refSize.Radius * _ringRadiusFactor * visual.Scale * screenScale;
+
+            var ringInScreen = TransformProjection.To2D(
+                Vector3.Transform(pose.Translation, projection.WorldToScreen)
+            );
+
+            var color = _selectedRingColor * visual.Alpha;
+
+            _circleRenderer.DrawCircle(ringInScreen, ringRadius, color, _ringThickness);
+        }
+    }
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Animation/ExpireAnimationCompletedEntitiesSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Animation/ExpireAnimationCompletedEntitiesSystem.cs
@@ -24,8 +24,11 @@ public sealed partial class ExpireAnimationCompletedEntitiesSystem(World world)
         if (animation.RawClip is not null)
             return;
 
-        // 没有指定动画剪辑也算是播完了
-        if (animation.Clip is null || animation.TimeElapsed.TotalSeconds > animation.Clip.Length)
+        // 只有指定了动画剪辑且播完了才销毁；Clip 为 null 表示尚未设置动画，不销毁
+        if (
+            animation.Clip is not null
+            && animation.TimeElapsed.TotalSeconds > animation.Clip.Length
+        )
             commands.Destroy(entity);
     }
 

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/DestroyBrokenRelationshipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/DestroyBrokenRelationshipsSystem.cs
@@ -43,3 +43,19 @@ public abstract class DestroyBrokenRelationshipsSystem<TRelationship>(World worl
         commandBuffer.Playback(world);
     }
 }
+
+/// <summary>
+/// 清理已损坏的星球-选择圈关系。当星球或选择圈被销毁时，自动清理关系实体。
+/// </summary>
+[SimulateSystem, ReactToStructuralChanges]
+[ChangeStructure]
+public sealed class DestroyBrokenPlanetSelectionRingsSystem(World world)
+    : DestroyBrokenRelationshipsSystem<PlanetSelectionRing>(world) { }
+
+/// <summary>
+/// 清理已损坏的视图-选择圈关系。当视图或选择圈被销毁时，自动清理关系实体。
+/// </summary>
+[SimulateSystem, ReactToStructuralChanges]
+[ChangeStructure]
+public sealed class DestroyBrokenViewSelectionRingsSystem(World world)
+    : DestroyBrokenRelationshipsSystem<ViewSelectionRing>(world) { }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/SpecializedIndexRelationshipSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/SpecializedIndexRelationshipSystem.cs
@@ -56,3 +56,29 @@ public sealed class IndexTrailAffiliationSystem(World world)
 [ExecuteAfter(typeof(ApplyAnimationSystem))]
 public sealed class IndexColorSyncTreeSystem(World world)
     : IndexRelationshipSystemBase<TreeRelationship<ColorSync>>(world) { }
+
+/// <summary>
+/// 索引星球与选择圈的关系，维护 AsPlanet 和 AsRing 索引组件。
+/// </summary>
+[SimulateSystem, AfterStructuralChanges]
+[
+    ReadCurr(typeof(PlanetSelectionRing)),
+    Write(typeof(PlanetSelectionRing.AsPlanet)),
+    Write(typeof(PlanetSelectionRing.AsRing))
+]
+[ExecuteAfter(typeof(ApplyAnimationSystem))]
+public sealed class IndexPlanetSelectionRingSystem(World world)
+    : IndexRelationshipSystemBase<PlanetSelectionRing>(world) { }
+
+/// <summary>
+/// 索引视图与选择圈的关系，维护 AsView 和 AsRing 索引组件。
+/// </summary>
+[SimulateSystem, AfterStructuralChanges]
+[
+    ReadCurr(typeof(ViewSelectionRing)),
+    Write(typeof(ViewSelectionRing.AsView)),
+    Write(typeof(ViewSelectionRing.AsRing))
+]
+[ExecuteAfter(typeof(ApplyAnimationSystem))]
+public sealed class IndexViewSelectionRingSystem(World world)
+    : IndexRelationshipSystemBase<ViewSelectionRing>(world) { }


### PR DESCRIPTION
**新增：**

- 选择圈从渲染系统直接绘制改为独立实体，通过星球↔选择圈和视图↔选择圈两个一对一关系同时关联到星球和视图，支持多视图场景下各视图独立维护选择圈
- 新增 VisualizeSelectionRingsSystem 负责从选择圈实体绘制淡出动画
- 发送飞船时（吸附松开、右键发送）为出发星球创建扩散式淡出动画，为目标星球创建收缩式淡出动画，与 SolarMax2 原版一致
- 取消选中时（非Shift点击新星球、点击空白处进入框选）为旧选中星球创建扩散式淡出动画
- 目标星球有淡出动画时不绘制预览圈，避免收缩式淡出和预览圈同时显示形成两个圈

**修复：**

- 动画剪辑为空时实体被错误销毁

Close #68