### PR TITLE
feat(ui): 移除菜单和初始化界面上下的黑条

### DIFF
--- a/OpenSolarMax.Game/Screens/Views/InitializationView.cs
+++ b/OpenSolarMax.Game/Screens/Views/InitializationView.cs
@@ -46,21 +46,6 @@ internal class InitializationView : ViewBase<InitializationViewModel>
             Background = new SolidBrush(_lightGray),
             Filler = new SolidBrush(_gray),
         };
-        var band1 = new Widget()
-        {
-            Background = new SolidBrush(_gray),
-            Height = 54,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Top,
-        };
-        var band2 = new Widget()
-        {
-            Background = new SolidBrush(_gray),
-            Height = 54,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Bottom,
-        };
-
         var stack = new VerticalStackPanel()
         {
             HorizontalAlignment = HorizontalAlignment.Center,
@@ -71,8 +56,6 @@ internal class InitializationView : ViewBase<InitializationViewModel>
 
         var panel = new Panel();
         panel.Widgets.Add(stack);
-        panel.Widgets.Add(band1);
-        panel.Widgets.Add(band2);
 
         _desktop = new Desktop();
         _desktop.Root = panel;

--- a/OpenSolarMax.Game/Screens/Views/MenuLikeView.cs
+++ b/OpenSolarMax.Game/Screens/Views/MenuLikeView.cs
@@ -23,8 +23,6 @@ internal class MenuLikeView
         IVisualConfigurableScreen<ChapterTransitionSourceState>,
         IVisualConfigurableScreen<ChapterTransitionTargetState>
 {
-    private static readonly Color _gray = new(0, 0, 0, 0x55);
-
     private readonly Desktop _desktop;
     private readonly Panel _rootPanel; // 使用 Panel 作为根控件以支持预览悬浮动画
     private readonly HorizontalScrollingBackground _pageBackground;
@@ -88,21 +86,6 @@ internal class MenuLikeView
             _exposureWhiteBase = game.Assets.Load<Texture2D>("Textures/Pixel.bmp");
         }
 
-        var band1 = new Widget()
-        {
-            Background = new SolidBrush(_gray),
-            Height = 54,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Top,
-        };
-        var band2 = new Widget()
-        {
-            Background = new SolidBrush(_gray),
-            Height = 54,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Bottom,
-        };
-
         // 顶栏
         var topPanel = new Panel()
         {
@@ -158,17 +141,11 @@ internal class MenuLikeView
 
         var grid = new Grid();
         grid.RowsProportions.Add(Proportion.Auto);
-        grid.RowsProportions.Add(Proportion.Auto);
         grid.RowsProportions.Add(Proportion.Fill);
-        grid.RowsProportions.Add(Proportion.Auto);
-        Grid.SetRow(band1, 0);
-        Grid.SetRow(topPanel, 1);
-        Grid.SetRow(_scrollViewer, 2);
-        Grid.SetRow(band2, 3);
-        grid.Widgets.Add(band1);
+        Grid.SetRow(topPanel, 0);
+        Grid.SetRow(_scrollViewer, 1);
         grid.Widgets.Add(topPanel);
         grid.Widgets.Add(_scrollViewer);
-        grid.Widgets.Add(band2);
 
         _rootPanel.Widgets.Add(grid);
 


### PR DESCRIPTION
移除菜单界面和初始化界面上下的半透明灰色条带（54px 高），这些条带是原作 SolarMax2 为适配非 16:9屏幕引入的，目前已无功能必要。

**变更内容：**

- 移除 `MenuLikeView` 中的上下黑条（band1/band2）
- 移除 `InitializationView` 中的上下黑条（band1/band2）
- 清理未使用的 `_gray` 变量

Close #67 