### PR TITLE
fix(ui): 游戏界面速度选项默认选中正常速度

### DIFF
--- a/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
+++ b/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
@@ -165,7 +165,7 @@ internal class LevelPlayView
                 Color = new Color(0xffaaaaff),
             },
         };
-        slowButton.Click += OnSpeedOptionChanged;
+        slowButton.IsToggledChanged += OnSpeedOptionChanged;
         var normalSpeedIcon = new IconRegion(
             game.Assets.Load<Nine.Graphics.TextureRegion>("UIs/Icons.Atlas.json:ButtonNormalSpeed")
         );
@@ -179,7 +179,7 @@ internal class LevelPlayView
                 Color = new Color(0xffaaaaff),
             },
         };
-        normalButton.Click += OnSpeedOptionChanged;
+        normalButton.IsToggledChanged += OnSpeedOptionChanged;
         var fastSpeedIcon = new IconRegion(
             game.Assets.Load<Nine.Graphics.TextureRegion>("UIs/Icons.Atlas.json:ButtonFastSpeed")
         );
@@ -192,7 +192,7 @@ internal class LevelPlayView
                 Color = new Color(0xffaaaaff),
             },
         };
-        fastButton.Click += OnSpeedOptionChanged;
+        fastButton.IsToggledChanged += OnSpeedOptionChanged;
         rightStack.Widgets.Add(slowButton);
         rightStack.Widgets.Add(normalButton);
         rightStack.Widgets.Add(fastButton);
@@ -319,6 +319,10 @@ internal class LevelPlayView
     {
         if (sender is not StateOpacityToggleButton theButton)
             throw new ArgumentException(null, nameof(sender));
+
+        // 排除本回调因按键取消按下而触发的情况
+        if (!theButton.IsToggled)
+            return;
 
         // 锁定当前按键
         theButton.Enabled = false;

--- a/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
+++ b/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
@@ -204,6 +204,9 @@ internal class LevelPlayView
         };
         grid.Widgets.Add(rightStack);
 
+        // 默认选中正常速度
+        normalButton.IsPressed = true;
+
         // 添加关卡通用界面。关卡UI结构如下:
         //
         // +---------------------------+
@@ -402,9 +405,6 @@ internal class LevelPlayView
 
     void IVisualConfigurable<GamePlayTransitionTargetState>.ExitConfigurationMode()
     {
-        // 世界更新速度正常化
-        ViewModel.SimulateSpeed = 1;
-
         // 移除悬浮视图控件
         _rootPanel.Widgets.Remove(_floatingWorldView);
         _floatingWorldView = null;
@@ -416,7 +416,12 @@ internal class LevelPlayView
             _embeddingWorldView.ToGlobal(Point.Zero),
             _embeddingWorldView.ActualBounds.Size
         );
-        return new GamePlayTransitionTargetState(targetPreviewLocation, 1, _background.Left);
+        var currentSpeed = _speedButtonsMap.First(b => b.Key.IsToggled).Value;
+        return new GamePlayTransitionTargetState(
+            targetPreviewLocation,
+            currentSpeed,
+            _background.Left
+        );
     }
 
     void IVisualConfigurable<GamePlayTransitionTargetState>.ApplyVisualState(


### PR DESCRIPTION
- 速度按钮从 `Click` 事件改为 `IsToggledChanged` 事件，这样才能在手动设置 `IsPressed` 时触发回调；
- 默认选中正常速度按钮；
- 过渡动画读取用户选择的速度而非硬编码为 1。

Close #43 