### PR TITLE
feat(simulate): 实现关卡胜利判定与胜利动效

### DIFF
--- a/OpenSolarMax.Game/Level/LevelFile.cs
+++ b/OpenSolarMax.Game/Level/LevelFile.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace OpenSolarMax.Game.Level;
 
 internal class LevelFile
@@ -5,4 +7,6 @@ internal class LevelFile
     public Dictionary<string, DeclarationStatement> Templates { get; } = [];
 
     public List<(string? Id, DeclarationStatement Statement)> Entities { get; } = [];
+
+    public JsonElement? Configs { get; set; }
 }

--- a/OpenSolarMax.Game/Level/LevelLoader.cs
+++ b/OpenSolarMax.Game/Level/LevelLoader.cs
@@ -20,6 +20,8 @@ internal class LevelLoader(
         public JsonElement[] Entities { get; set; } = [];
 
         public JsonElement Player { get; set; }
+
+        public JsonElement? Configs { get; set; }
     }
 
     public LevelFile Load(IFileSystem fs, IAssetsManager assets, in UPath path)
@@ -63,7 +65,7 @@ internal class LevelLoader(
             )
         );
 
-        var level = new LevelFile();
+        var level = new LevelFile() { Configs = jsonLevel.Configs };
 
         // 解析模板语句
         foreach (var (templateKey, templateJsonElement) in jsonLevel.Templates)

--- a/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
+++ b/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
+using System.Text.Json;
 using Arch.Buffer;
 using Arch.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Xna.Framework.Graphics;
 using Nine.Assets;
 using OpenSolarMax.Game.Modding;
@@ -76,6 +78,23 @@ internal class LevelRuntimeLoader
 
     public LevelRuntime LoadLevel(LevelFile level)
     {
+        // 构造关卡级配置（叠加到模组 LocalConfigs 之上）
+        IConfigurationRoot effectiveConfigs;
+        if (level.Configs is { } configsJson)
+        {
+            var jsonStream = new MemoryStream(
+                System.Text.Encoding.UTF8.GetBytes(configsJson.GetRawText())
+            );
+            effectiveConfigs = new ConfigurationBuilder()
+                .AddConfiguration(_levelModContext.LocalConfigs)
+                .AddJsonStream(jsonStream)
+                .Build();
+        }
+        else
+        {
+            effectiveConfigs = _levelModContext.LocalConfigs;
+        }
+
         // 构造世界和四大系统
         var world = World.Create();
         var inputSystem = new AggregateSystem(
@@ -85,7 +104,7 @@ internal class LevelRuntimeLoader
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
                 [typeof(IConceptFactory)] = _factory,
-                [typeof(IConfigurationRoot)] = _levelModContext.LocalConfigs,
+                [typeof(IConfigurationRoot)] = effectiveConfigs,
             },
             _behaviors.HookImplMethods.ToDictionary(
                 kv => kv.Key,
@@ -99,7 +118,7 @@ internal class LevelRuntimeLoader
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
                 [typeof(IConceptFactory)] = _factory,
-                [typeof(IConfigurationRoot)] = _levelModContext.LocalConfigs,
+                [typeof(IConfigurationRoot)] = effectiveConfigs,
             },
             _behaviors.HookImplMethods.ToDictionary(
                 kv => kv.Key,
@@ -113,7 +132,7 @@ internal class LevelRuntimeLoader
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
                 [typeof(IConceptFactory)] = _factory,
-                [typeof(IConfigurationRoot)] = _levelModContext.LocalConfigs,
+                [typeof(IConfigurationRoot)] = effectiveConfigs,
             },
             _behaviors.HookImplMethods.ToDictionary(
                 kv => kv.Key,
@@ -127,7 +146,7 @@ internal class LevelRuntimeLoader
             {
                 [typeof(GraphicsDevice)] = _game.GraphicsDevice,
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
-                [typeof(IConfigurationRoot)] = _levelModContext.LocalConfigs,
+                [typeof(IConfigurationRoot)] = effectiveConfigs,
             },
             _behaviors.HookImplMethods.ToDictionary(
                 kv => kv.Key,

--- a/OpenSolarMax.Game/Modding/UI/GameState.cs
+++ b/OpenSolarMax.Game/Modding/UI/GameState.cs
@@ -1,0 +1,16 @@
+namespace OpenSolarMax.Game.Modding.UI;
+
+/// <summary>
+/// 游戏状态。挂在 View 实体上，供 shell 层轮询决定是否退出关卡。
+/// </summary>
+public struct GameState
+{
+    public GameStatus Status;
+}
+
+public enum GameStatus
+{
+    Playing,
+    Victory,
+    Failed,
+}

--- a/OpenSolarMax.Game/OpenSolarMax.Game.csproj
+++ b/OpenSolarMax.Game/OpenSolarMax.Game.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="CsToml.Extensions.Configuration" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
     <PackageReference
       Include="Microsoft.Extensions.Configuration.EnvironmentVariables"
       Version="10.0.1"

--- a/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
+++ b/OpenSolarMax.Game/Screens/Views/LevelPlayView.cs
@@ -28,6 +28,7 @@ internal class LevelPlayView
 
     private readonly RenderTarget2D _uiRenderTarget;
     private readonly SpriteBatch _uiSpriteBatch;
+    private bool _exited = false;
 
     public LevelPlayView(LevelPlayViewModel viewModel, SolarMax game)
         : base(viewModel, game)
@@ -357,6 +358,21 @@ internal class LevelPlayView
         ViewModel.InputSystem.Update(gameTime);
 
         base.Update(gameTime);
+
+        if (!_exited)
+        {
+            ViewModel.World.Query(
+                new QueryDescription().WithAll<GameState>(),
+                (ref GameState state) =>
+                {
+                    if (state.Status != GameStatus.Playing && !_exited)
+                    {
+                        Game.ScreenManager.Backward();
+                        _exited = true;
+                    }
+                }
+            );
+        }
     }
 
     public override void Draw(GameTime gameTime)
@@ -389,6 +405,13 @@ internal class LevelPlayView
         _uiSpriteBatch.Begin(blendState: BlendState.Additive);
         _uiSpriteBatch.Draw(_uiRenderTarget, Vector2.Zero, Color.White);
         _uiSpriteBatch.End();
+    }
+
+    public override void Dispose()
+    {
+        _uiRenderTarget.Dispose();
+        _uiSpriteBatch.Dispose();
+        base.Dispose();
     }
 
     #region GamePlayTransitionTargetState

--- a/OpenSolarMax.Levels.S2/Levels/01.json
+++ b/OpenSolarMax.Levels.S2/Levels/01.json
@@ -1,0 +1,21 @@
+{
+    "configs": {
+        "systems:victory:require_all_planets": true
+    },
+
+    "templates": {
+        "planet50": { "$base": "planet", "radius": 32.0, "volume": 500, "population": 50, "produceSpeed": 1.0 },
+        "planet60": { "$base": "planet", "radius": 38.4, "volume": 600, "population": 60, "produceSpeed": 1.2 },
+        "blue": { "$base": "team", "color": "#5FB6FF", "workload": 1, "attack": 0.1, "health": 1 }
+    },
+
+    "entities": [
+        { "$id": "blue", "$base": "blue" },
+
+        { "$base": "view", "size": [ 1024, 540 ], "position": [ 512, 384 ], "depth": [ -1000, 1000 ], "team": "blue" },
+
+        { "$base": "planet60", "team": "blue", "position": [ 352, 472 ], "ships": 60 },
+
+        { "$base": "planet50", "position": [ 672, 296 ] }
+    ]
+}

--- a/OpenSolarMax.Levels.S2/Levels/02.json
+++ b/OpenSolarMax.Levels.S2/Levels/02.json
@@ -1,0 +1,19 @@
+{
+    "templates": {
+        "planet50": { "$base": "planet", "radius": 32.0, "volume": 500, "population": 50, "produceSpeed": 1.0 },
+        "planet60": { "$base": "planet", "radius": 38.4, "volume": 600, "population": 60, "produceSpeed": 1.2 },
+        "blue": { "$base": "team", "color": "#5FB6FF", "workload": 1, "attack": 0.1, "health": 1 }
+    },
+
+    "entities": [
+        { "$id": "blue", "$base": "blue" },
+        { "$id": "red", "$base": "blue", "color": "#FF5D93" },
+
+        { "$base": "view", "size": [ 1024, 540 ], "position": [ 512, 384 ], "depth": [ -1000, 1000 ], "team": "blue" },
+
+        { "$base": "planet60", "team": "blue", "position": [ 512, 288 ], "ships": 60 },
+        { "$base": "planet50", "team": "red", "position": [ 384, 480 ], "ships": 30 },
+
+        { "$base": "planet50", "position": [ 640, 480 ] }
+    ]
+}

--- a/OpenSolarMax.Mods.Core/Components/PendingVictoryEffect.cs
+++ b/OpenSolarMax.Mods.Core/Components/PendingVictoryEffect.cs
@@ -1,0 +1,26 @@
+using Arch.Core;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 待触发的胜利波纹效果。
+/// 拥有该组件的实体在倒计时归零时触发单颗星球的"爆炸+改阵营+重置殖民"全套动作。
+/// 由 GameOverSystem 在胜利帧为每颗星球创建。
+/// </summary>
+public struct PendingVictoryEffect() : ICountDownTimer
+{
+    /// <summary>
+    /// 剩余时间
+    /// </summary>
+    public TimeSpan TimeLeft { get; set; }
+
+    /// <summary>
+    /// 要操作的星球实体
+    /// </summary>
+    public Entity Planet = Entity.Null;
+
+    /// <summary>
+    /// 获胜方阵营实体
+    /// </summary>
+    public Entity Winner = Entity.Null;
+}

--- a/OpenSolarMax.Mods.Core/Components/PendingVictoryEffect.cs
+++ b/OpenSolarMax.Mods.Core/Components/PendingVictoryEffect.cs
@@ -1,26 +1,14 @@
-using Arch.Core;
+using OpenSolarMax.Game.Modding.ECS;
 
 namespace OpenSolarMax.Mods.Core.Components;
 
 /// <summary>
-/// 待触发的胜利波纹效果。
-/// 拥有该组件的实体在倒计时归零时触发单颗星球的"爆炸+改阵营+重置殖民"全套动作。
+/// 待触发的胜利波纹效果计时器。
+/// 实现 ICountDownTimer 供 CountDownSystemBase 倒数。
 /// 由 GameOverSystem 在胜利帧为每颗星球创建。
 /// </summary>
-public struct PendingVictoryEffect() : ICountDownTimer
+[Component]
+public struct PendingVictoryEffect : ICountDownTimer
 {
-    /// <summary>
-    /// 剩余时间
-    /// </summary>
     public TimeSpan TimeLeft { get; set; }
-
-    /// <summary>
-    /// 要操作的星球实体
-    /// </summary>
-    public Entity Planet = Entity.Null;
-
-    /// <summary>
-    /// 获胜方阵营实体
-    /// </summary>
-    public Entity Winner = Entity.Null;
 }

--- a/OpenSolarMax.Mods.Core/Components/Victory.cs
+++ b/OpenSolarMax.Mods.Core/Components/Victory.cs
@@ -1,0 +1,13 @@
+using OpenSolarMax.Game.Modding.ECS;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 标记一个队伍实体并追踪其是否已获胜。
+/// 初始为 <see cref="HasWon"/> = false，由 <see cref="DetectVictorySystem"/> 在胜利条件满足时设为 true
+/// </summary>
+[Component]
+public struct Victory
+{
+    public bool HasWon;
+}

--- a/OpenSolarMax.Mods.Core/Components/VictoryEffectMarker.cs
+++ b/OpenSolarMax.Mods.Core/Components/VictoryEffectMarker.cs
@@ -1,0 +1,10 @@
+using OpenSolarMax.Game.Modding.ECS;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 标记胜利特效已触发。由 <see cref="GameOverSystem"/> 在首次触发胜利特效时创建，
+/// 用于防止特效重复播放。实体常驻至关卡 World 销毁。
+/// </summary>
+[Component]
+public struct VictoryEffectMarker;

--- a/OpenSolarMax.Mods.Core/Components/VictoryEffectTarget.cs
+++ b/OpenSolarMax.Mods.Core/Components/VictoryEffectTarget.cs
@@ -1,0 +1,24 @@
+using Arch.Core;
+using OpenSolarMax.Mods.Core.SourceGenerators;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 胜利波纹效果的目标星球和获胜方。
+/// 与 PendingVictoryEffect 计时器配套使用。
+/// </summary>
+[Relationship]
+public partial struct VictoryEffectTarget()
+{
+    /// <summary>
+    /// 要操作的星球实体
+    /// </summary>
+    [Participant]
+    public Entity Planet = Entity.Null;
+
+    /// <summary>
+    /// 获胜方阵营实体
+    /// </summary>
+    [Participant]
+    public Entity Winner = Entity.Null;
+}

--- a/OpenSolarMax.Mods.Core/Components/VictoryExitTimer.cs
+++ b/OpenSolarMax.Mods.Core/Components/VictoryExitTimer.cs
@@ -1,0 +1,16 @@
+using OpenSolarMax.Game.Modding.ECS;
+
+namespace OpenSolarMax.Mods.Core.Components;
+
+/// <summary>
+/// 胜利退出计时器组件。
+/// 拥有该组件的实体在胜利后开始倒计时，归零时触发关卡退出
+/// </summary>
+[Component]
+public struct VictoryExitTimer : ICountDownTimer
+{
+    /// <summary>
+    /// 剩余时间
+    /// </summary>
+    public TimeSpan TimeLeft { get; set; }
+}

--- a/OpenSolarMax.Mods.Core/Concepts/PendingVictoryEffect.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/PendingVictoryEffect.cs
@@ -1,0 +1,46 @@
+using Arch.Buffer;
+using Arch.Core;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Concepts;
+
+public static partial class ConceptNames
+{
+    public const string PendingVictoryEffect = "PendingVictoryEffect";
+}
+
+[Define(ConceptNames.PendingVictoryEffect)]
+public abstract class PendingVictoryEffectDefinition : IDefinition
+{
+    public static Signature Signature { get; } = new(typeof(PendingVictoryEffect));
+}
+
+[Describe(ConceptNames.PendingVictoryEffect)]
+public class PendingVictoryEffectDescription : IDescription
+{
+    public required Entity Planet { get; set; }
+    public required Entity Winner { get; set; }
+    public required TimeSpan TimeLeft { get; set; }
+}
+
+[Apply(ConceptNames.PendingVictoryEffect)]
+public class PendingVictoryEffectApplier : IApplier<PendingVictoryEffectDescription>
+{
+    public void Apply(
+        CommandBuffer commandBuffer,
+        Entity entity,
+        PendingVictoryEffectDescription desc
+    )
+    {
+        commandBuffer.Set(
+            in entity,
+            new PendingVictoryEffect
+            {
+                Planet = desc.Planet,
+                Winner = desc.Winner,
+                TimeLeft = desc.TimeLeft,
+            }
+        );
+    }
+}

--- a/OpenSolarMax.Mods.Core/Concepts/Relationships/PendingVictoryEffect.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Relationships/PendingVictoryEffect.cs
@@ -13,7 +13,8 @@ public static partial class ConceptNames
 [Define(ConceptNames.PendingVictoryEffect)]
 public abstract class PendingVictoryEffectDefinition : IDefinition
 {
-    public static Signature Signature { get; } = new(typeof(PendingVictoryEffect));
+    public static Signature Signature { get; } =
+        new(typeof(PendingVictoryEffect), typeof(VictoryEffectTarget));
 }
 
 [Describe(ConceptNames.PendingVictoryEffect)]
@@ -33,14 +34,11 @@ public class PendingVictoryEffectApplier : IApplier<PendingVictoryEffectDescript
         PendingVictoryEffectDescription desc
     )
     {
+        commandBuffer.Set(in entity, new PendingVictoryEffect { TimeLeft = desc.TimeLeft });
+
         commandBuffer.Set(
             in entity,
-            new PendingVictoryEffect
-            {
-                Planet = desc.Planet,
-                Winner = desc.Winner,
-                TimeLeft = desc.TimeLeft,
-            }
+            new VictoryEffectTarget { Planet = desc.Planet, Winner = desc.Winner }
         );
     }
 }

--- a/OpenSolarMax.Mods.Core/Concepts/Team.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Team.cs
@@ -27,6 +27,8 @@ public abstract class TeamDefinition : IDefinition
             // 隶属关系
             typeof(InTeam.AsTeam),
             typeof(TeamPopulationRegistry),
+            // 胜利状态
+            typeof(Victory),
             // Ai
             typeof(Ai),
             typeof(AiTimer),
@@ -79,6 +81,8 @@ public class TeamApplier : IApplier<TeamDescription>
         commandBuffer.Set(in entity, new Jumpable { Speed = 100 });
 
         commandBuffer.Set(in entity, new ColonizationAbility { ProgressPerSecond = 1 });
+
+        commandBuffer.Set(in entity, new Victory { HasWon = false });
 
         commandBuffer.Set(in entity, new Ai { Enabled = false });
         commandBuffer.Set(in entity, new AiCooldown { Duration = TimeSpan.FromSeconds(3) });

--- a/OpenSolarMax.Mods.Core/Concepts/VictoryExitTimer.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/VictoryExitTimer.cs
@@ -1,0 +1,32 @@
+using Arch.Buffer;
+using Arch.Core;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Concepts;
+
+public static partial class ConceptNames
+{
+    public const string VictoryExitTimer = "VictoryExitTimer";
+}
+
+[Define(ConceptNames.VictoryExitTimer)]
+public abstract class VictoryExitTimerDefinition : IDefinition
+{
+    public static Signature Signature { get; } = new(typeof(VictoryExitTimer));
+}
+
+[Describe(ConceptNames.VictoryExitTimer)]
+public class VictoryExitTimerDescription : IDescription
+{
+    public required TimeSpan TimeLeft { get; set; }
+}
+
+[Apply(ConceptNames.VictoryExitTimer)]
+public class VictoryExitTimerApplier : IApplier<VictoryExitTimerDescription>
+{
+    public void Apply(CommandBuffer commandBuffer, Entity entity, VictoryExitTimerDescription desc)
+    {
+        commandBuffer.Set(in entity, new VictoryExitTimer { TimeLeft = desc.TimeLeft });
+    }
+}

--- a/OpenSolarMax.Mods.Core/Concepts/VictoryFlash.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/VictoryFlash.cs
@@ -1,0 +1,78 @@
+using Arch.Buffer;
+using Arch.Core;
+using Microsoft.Xna.Framework;
+using Nine.Animations;
+using Nine.Assets;
+using Nine.Graphics;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Concepts;
+
+public static partial class ConceptNames
+{
+    public const string VictoryFlash = "VictoryFlash";
+}
+
+[Define(ConceptNames.VictoryFlash)]
+public abstract class VictoryFlashDefinition : IDefinition
+{
+    public static Signature Signature { get; } =
+        new(
+            typeof(AbsoluteTransform),
+            typeof(Sprite),
+            typeof(Animation),
+            typeof(ExpireAfterAnimationCompleted)
+        );
+}
+
+[Describe(ConceptNames.VictoryFlash)]
+public class VictoryFlashDescription : IDescription
+{
+    public required Color Color { get; set; }
+}
+
+[Apply(ConceptNames.VictoryFlash)]
+public class VictoryFlashApplier(IAssetsManager assets) : IApplier<VictoryFlashDescription>
+{
+    private readonly TextureRegion _whitePixel = assets.Load<TextureRegion>(
+        "Textures/Pixel.json:AtCenter"
+    );
+
+    private readonly AnimationClip<Entity> _flashAnimation = assets.Load<AnimationClip<Entity>>(
+        "Animations/VictoryFlashAlpha.json"
+    );
+
+    public void Apply(CommandBuffer commandBuffer, Entity entity, VictoryFlashDescription desc)
+    {
+        commandBuffer.Set(
+            in entity,
+            new AbsoluteTransform { Translation = new Vector3(0, 0, 1000) }
+        );
+
+        commandBuffer.Set(
+            in entity,
+            new Sprite
+            {
+                Texture = _whitePixel,
+                Color = desc.Color,
+                Alpha = 0f,
+                Size = new Vector2(1e6f, 1e6f),
+                Scale = Vector2.One,
+                Blend = SpriteBlend.Additive,
+            }
+        );
+
+        commandBuffer.Set(
+            in entity,
+            new Animation
+            {
+                Clip = _flashAnimation,
+                TimeElapsed = TimeSpan.Zero,
+                TimeOffset = TimeSpan.Zero,
+            }
+        );
+
+        commandBuffer.Set(in entity, new ExpireAfterAnimationCompleted());
+    }
+}

--- a/OpenSolarMax.Mods.Core/Concepts/View.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/View.cs
@@ -41,7 +41,9 @@ public abstract class ViewDefinition : IDefinition
             typeof(TotalPopulationWidget),
             typeof(FleetSliderWidget),
             // 视图标识
-            typeof(ViewTag)
+            typeof(ViewTag),
+            // 游戏状态
+            typeof(GameState)
         );
 }
 
@@ -105,5 +107,8 @@ public class ViewApplier(
         // 初始化 UI
         commandBuffer.Set(in entity, new TotalPopulationWidget(assets, populationLabelConfigs));
         commandBuffer.Set(in entity, new FleetSliderWidget(assets, fleetSliderConfigs));
+
+        // 初始化游戏状态
+        commandBuffer.Set(in entity, new GameState { Status = GameStatus.Playing });
     }
 }

--- a/OpenSolarMax.Mods.Core/Content/Animations/VictoryFlashAlpha.json
+++ b/OpenSolarMax.Mods.Core/Content/Animations/VictoryFlashAlpha.json
@@ -1,0 +1,10 @@
+{
+    "duration": 2.0,
+    "curves": {
+        "Sprite::Alpha": [
+            { "time": 0.0, "value": 0.0, "type": "Linear" },
+            { "time": 1.0, "value": 0.4, "type": "Linear" },
+            { "time": 2.0, "value": 0.0, "type": "Linear" }
+        ]
+    }
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/DetectVictorySystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/DetectVictorySystem.cs
@@ -1,0 +1,80 @@
+using Arch.Core;
+using Arch.Core.Extensions;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, AfterStructuralChanges]
+[
+    ReadCurr(typeof(TeamPopulationRegistry)),
+    ReadCurr(typeof(InTeam.AsTeam)),
+    ReadCurr(typeof(InTeam.AsAffiliate)),
+    ReadCurr(typeof(Colonizable)),
+    Write(typeof(Victory))
+]
+[ExecuteAfter(typeof(ApplyAnimationSystem))]
+public sealed partial class DetectVictorySystem(World world) : ICalcSystem
+{
+    [Query]
+    [All<InTeam.AsTeam, Victory>]
+    private static void CheckVictoryAlreadyDetected(ref Victory victory, [Data] ref bool hasVictory)
+    {
+        if (victory.HasWon)
+            hasVictory = true;
+    }
+
+    [Query]
+    [All<InTeam.AsTeam, TeamPopulationRegistry>]
+    private static void FindSurvivingTeams(
+        Entity team,
+        in TeamPopulationRegistry registry,
+        [Data] List<Entity> survivingTeams
+    )
+    {
+        if (registry.CurrentPopulation > 0)
+            survivingTeams.Add(team);
+    }
+
+    [Query]
+    [All<InTeam.AsAffiliate, Colonizable>]
+    private void FindEnemyNodes(
+        Entity _, // Arch.System.SourceGenerators 对 [Data] Entity 支持有问题，此处强行占位
+        in InTeam.AsAffiliate affiliation,
+        [Data] Entity winnerTeam,
+        [Data] List<Entity> enemyNodes
+    )
+    {
+        if (affiliation.Relationship is null)
+            return;
+
+        var team = affiliation.Relationship.Value.Copy.Team;
+        if (team != winnerTeam)
+            enemyNodes.Add(team);
+    }
+
+    public void Update()
+    {
+        var hasVictory = false;
+        CheckVictoryAlreadyDetectedQuery(world, ref hasVictory);
+        if (hasVictory)
+            return;
+
+        var survivingTeams = new List<Entity>();
+        FindSurvivingTeamsQuery(world, survivingTeams);
+
+        if (survivingTeams.Count != 1)
+            return;
+
+        var winner = survivingTeams[0];
+
+        var enemyNodes = new List<Entity>();
+        FindEnemyNodesQuery(world, winner, enemyNodes);
+        if (enemyNodes.Count > 0)
+            return;
+
+        winner.Get<Victory>().HasWon = true;
+    }
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/DetectVictorySystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/DetectVictorySystem.cs
@@ -2,6 +2,8 @@ using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
 using Arch.System.SourceGenerator;
+using Microsoft.Extensions.Configuration;
+using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 
@@ -16,8 +18,13 @@ namespace OpenSolarMax.Mods.Core.Systems;
     Write(typeof(Victory))
 ]
 [ExecuteAfter(typeof(ApplyAnimationSystem))]
-public sealed partial class DetectVictorySystem(World world) : ICalcSystem
+public sealed partial class DetectVictorySystem(
+    World world,
+    [Section("systems:victory")] IConfiguration configs
+) : ICalcSystem
 {
+    private readonly bool _requireAllPlanets = configs.GetValue<bool>("require_all_planets");
+
     [Query]
     [All<InTeam.AsTeam, Victory>]
     private static void CheckVictoryAlreadyDetected(ref Victory victory, [Data] ref bool hasVictory)
@@ -48,7 +55,11 @@ public sealed partial class DetectVictorySystem(World world) : ICalcSystem
     )
     {
         if (affiliation.Relationship is null)
+        {
+            if (_requireAllPlanets)
+                enemyNodes.Add(Entity.Null);
             return;
+        }
 
         var team = affiliation.Relationship.Value.Copy.Team;
         if (team != winnerTeam)

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/GameOverSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/GameOverSystem.cs
@@ -3,7 +3,10 @@ using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
 using Arch.System.SourceGenerator;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Xna.Framework;
 using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Game.Modding.Configuration;
 using OpenSolarMax.Game.Modding.ECS;
 using OpenSolarMax.Mods.Core.Components;
 using OpenSolarMax.Mods.Core.Concepts;
@@ -20,15 +23,18 @@ namespace OpenSolarMax.Mods.Core.Systems;
     ReadPrev(typeof(AbsoluteTransform)),
     ReadPrev(typeof(ReferenceSize)),
     ReadPrev(typeof(VictoryEffectMarker)),
-    Iterate(typeof(ColonizationState)),
     ChangeStructure
 ]
-[ExecuteBefore(typeof(ProgressColonizationSystem))]
-[ExecuteBefore(typeof(SettleColonizationSystem))]
 [ExecuteBefore(typeof(ApplyAnimationSystem))]
-public sealed partial class GameOverSystem(World world, IConceptFactory factory)
-    : ICalcSystemWithStructuralChanges
+public sealed partial class GameOverSystem(
+    World world,
+    IConceptFactory factory,
+    [Section("systems:victory")] IConfiguration configs
+) : ICalcSystemWithStructuralChanges
 {
+    private readonly float _waveMaxInterval = configs.GetValue<float>("wave_max_interval");
+    private readonly float _waveTotalSeconds = configs.GetValue<float>("wave_total_seconds");
+
     [Query]
     [All<InTeam.AsTeam, Victory>]
     private static void FindWinner(Entity team, in Victory victory, [Data] List<Entity> winners)
@@ -39,59 +45,13 @@ public sealed partial class GameOverSystem(World world, IConceptFactory factory)
 
     [Query]
     [All<InTeam.AsAffiliate, Colonizable, ColonizationState, AbsoluteTransform, ReferenceSize>]
-    private void CreateHaloExplosions(
+    private static void FindAllPlanets(
         Entity planet,
-        in Colonizable colonizable,
-        ref ColonizationState state,
-        in InTeam.AsAffiliate affiliation,
         in AbsoluteTransform transform,
-        in ReferenceSize size,
-        [Data] Entity winner,
-        [Data] CommandBuffer commandBuffer
+        [Data] List<(Entity Planet, Vector2 Pos)> collected
     )
     {
-        factory.Make(
-            world,
-            commandBuffer,
-            ConceptNames.HaloExplosion,
-            new HaloExplosionDescription
-            {
-                Color = winner.Get<TeamReferenceColor>().Value,
-                Position = transform.Translation,
-                PlanetRadius = size.Radius,
-            }
-        );
-
-        if (affiliation.Relationship is null)
-        {
-            factory.Make(
-                world,
-                commandBuffer,
-                new InTeamDescription() { Team = winner, Affiliate = planet }
-            );
-
-            state.Team = winner;
-            state.Progress = colonizable.Volume;
-            state.Event = ColonizationEvent.Idle;
-        }
-        else
-        {
-            var team = affiliation.Relationship.Value.Copy.Team;
-            if (team != winner)
-            {
-                commandBuffer.Destroy(affiliation.Relationship!.Value.Ref);
-
-                factory.Make(
-                    world,
-                    commandBuffer,
-                    new InTeamDescription() { Team = winner, Affiliate = planet }
-                );
-
-                state.Team = winner;
-                state.Progress = colonizable.Volume;
-                state.Event = ColonizationEvent.Idle;
-            }
-        }
+        collected.Add((planet, new Vector2(transform.Translation.X, transform.Translation.Y)));
     }
 
     public void Update(CommandBuffer commandBuffer)
@@ -111,24 +71,66 @@ public sealed partial class GameOverSystem(World world, IConceptFactory factory)
 
         var winner = winners[0];
 
+        // 收集所有星球（含中立和己方），计算 XY 质心
+        var planets = new List<(Entity Planet, Vector2 Pos)>();
+        FindAllPlanetsQuery(world, planets);
+
+        var centroid = planets.Aggregate(Vector2.Zero, (acc, p) => acc + p.Pos) / planets.Count;
+
+        // 按距质心距离排序（近→远）；距离相近（差 ≤ 容差）时按 atan2 角度升序排（+X 为零，逆时针为正）
+        var sorted = planets
+            .Select(p =>
+            {
+                var dx = p.Pos.X - centroid.X;
+                var dy = p.Pos.Y - centroid.Y;
+                var dist = MathF.Sqrt(dx * dx + dy * dy);
+                var angle = MathF.Atan2(dy, dx);
+                if (angle < 0)
+                    angle += 2 * MathF.PI;
+                return (p.Planet, Dist: dist, Angle: angle);
+            })
+            .OrderBy(p => p.Dist)
+            .ThenBy(p => p.Angle)
+            .ToList();
+
+        // 不分桶：每颗星球按排序顺序依次触发，rank 即序号
+        var ranked = sorted.Select((p, i) => (Rank: i, p.Planet)).ToList();
+
+        // 计算波纹间隔 Δ = min(wave_max_interval, wave_total_seconds / M)
+        // 其中 M 为星球总数
+        var M = ranked.Count > 0 ? ranked.Count : 1;
+        var delta = MathF.Min(_waveMaxInterval, _waveTotalSeconds / MathF.Max(1, M));
+
+        // 为每颗星球创建调度实体，延迟 = rank × Δ 秒
+        foreach (var (r, planet) in ranked)
+        {
+            factory.Make(
+                world,
+                commandBuffer,
+                new PendingVictoryEffectDescription
+                {
+                    Planet = planet,
+                    Winner = winner,
+                    TimeLeft = TimeSpan.FromSeconds(r * delta),
+                }
+            );
+        }
+
         commandBuffer.Create(new Signature(typeof(VictoryEffectMarker)));
 
         factory.Make(
             world,
             commandBuffer,
             ConceptNames.VictoryExitTimer,
-            new VictoryExitTimerDescription { TimeLeft = TimeSpan.FromSeconds(2) }
+            new VictoryExitTimerDescription { TimeLeft = TimeSpan.FromSeconds(_waveTotalSeconds) }
         );
 
         var flashColor = winner.Get<TeamReferenceColor>().Value;
-
         factory.Make(
             world,
             commandBuffer,
             ConceptNames.VictoryFlash,
             new VictoryFlashDescription { Color = flashColor }
         );
-
-        CreateHaloExplosionsQuery(world, winner, commandBuffer);
     }
 }

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/GameOverSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/GameOverSystem.cs
@@ -1,0 +1,134 @@
+using Arch.Buffer;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Concepts;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, BeforeStructuralChanges]
+// 按理说应当使用 ReadCurr，但是目前不支持 StructuralChange 位于 PostUpdate 后边，因此只能晚一帧生效
+[
+    ReadPrev(typeof(Victory)),
+    ReadPrev(typeof(InTeam.AsTeam)),
+    ReadPrev(typeof(InTeam.AsAffiliate)),
+    ReadPrev(typeof(Colonizable)),
+    ReadPrev(typeof(AbsoluteTransform)),
+    ReadPrev(typeof(ReferenceSize)),
+    ReadPrev(typeof(VictoryEffectMarker)),
+    Iterate(typeof(ColonizationState)),
+    ChangeStructure
+]
+[ExecuteBefore(typeof(ProgressColonizationSystem))]
+[ExecuteBefore(typeof(SettleColonizationSystem))]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class GameOverSystem(World world, IConceptFactory factory)
+    : ICalcSystemWithStructuralChanges
+{
+    [Query]
+    [All<InTeam.AsTeam, Victory>]
+    private static void FindWinner(Entity team, in Victory victory, [Data] List<Entity> winners)
+    {
+        if (victory.HasWon)
+            winners.Add(team);
+    }
+
+    [Query]
+    [All<InTeam.AsAffiliate, Colonizable, ColonizationState, AbsoluteTransform, ReferenceSize>]
+    private void CreateHaloExplosions(
+        Entity planet,
+        in Colonizable colonizable,
+        ref ColonizationState state,
+        in InTeam.AsAffiliate affiliation,
+        in AbsoluteTransform transform,
+        in ReferenceSize size,
+        [Data] Entity winner,
+        [Data] CommandBuffer commandBuffer
+    )
+    {
+        factory.Make(
+            world,
+            commandBuffer,
+            ConceptNames.HaloExplosion,
+            new HaloExplosionDescription
+            {
+                Color = winner.Get<TeamReferenceColor>().Value,
+                Position = transform.Translation,
+                PlanetRadius = size.Radius,
+            }
+        );
+
+        if (affiliation.Relationship is null)
+        {
+            factory.Make(
+                world,
+                commandBuffer,
+                new InTeamDescription() { Team = winner, Affiliate = planet }
+            );
+
+            state.Team = winner;
+            state.Progress = colonizable.Volume;
+            state.Event = ColonizationEvent.Idle;
+        }
+        else
+        {
+            var team = affiliation.Relationship.Value.Copy.Team;
+            if (team != winner)
+            {
+                commandBuffer.Destroy(affiliation.Relationship!.Value.Ref);
+
+                factory.Make(
+                    world,
+                    commandBuffer,
+                    new InTeamDescription() { Team = winner, Affiliate = planet }
+                );
+
+                state.Team = winner;
+                state.Progress = colonizable.Volume;
+                state.Event = ColonizationEvent.Idle;
+            }
+        }
+    }
+
+    public void Update(CommandBuffer commandBuffer)
+    {
+        var winners = new List<Entity>();
+        FindWinnerQuery(world, winners);
+        if (winners.Count == 0)
+            return;
+
+        var hasEffectMarker = false;
+        world.Query(
+            new QueryDescription().WithAll<VictoryEffectMarker>(),
+            (Entity _) => hasEffectMarker = true
+        );
+        if (hasEffectMarker)
+            return;
+
+        var winner = winners[0];
+
+        commandBuffer.Create(new Signature(typeof(VictoryEffectMarker)));
+
+        factory.Make(
+            world,
+            commandBuffer,
+            ConceptNames.VictoryExitTimer,
+            new VictoryExitTimerDescription { TimeLeft = TimeSpan.FromSeconds(2) }
+        );
+
+        var flashColor = winner.Get<TeamReferenceColor>().Value;
+
+        factory.Make(
+            world,
+            commandBuffer,
+            ConceptNames.VictoryFlash,
+            new VictoryFlashDescription { Color = flashColor }
+        );
+
+        CreateHaloExplosionsQuery(world, winner, commandBuffer);
+    }
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/PendingVictoryEffectSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/PendingVictoryEffectSystem.cs
@@ -19,7 +19,12 @@ public sealed partial class PendingVictoryEffectCountDownSystem(World world)
     : CountDownSystemBase<PendingVictoryEffect>(world) { }
 
 [SimulateSystem, BeforeStructuralChanges]
-[ReadCurr(typeof(PendingVictoryEffect)), Write(typeof(ColonizationState)), ChangeStructure]
+[
+    ReadCurr(typeof(PendingVictoryEffect)),
+    ReadCurr(typeof(VictoryEffectTarget)),
+    Write(typeof(ColonizationState)),
+    ChangeStructure
+]
 [ExecuteBefore(typeof(ProgressColonizationSystem))]
 [ExecuteBefore(typeof(SettleColonizationSystem))]
 [ExecuteBefore(typeof(ApplyAnimationSystem))]
@@ -31,14 +36,15 @@ public sealed partial class FirePendingVictoryEffectSystem(World world, IConcept
     private void TriggerFire(
         Entity pending,
         in PendingVictoryEffect schedule,
+        in VictoryEffectTarget target,
         [Data] CommandBuffer commandBuffer
     )
     {
         if (schedule.TimeLeft > TimeSpan.Zero)
             return;
 
-        var planet = schedule.Planet;
-        var winner = schedule.Winner;
+        var planet = target.Planet;
+        var winner = target.Winner;
 
         // 创建 HaloExplosion 特效
         var transform = planet.Get<AbsoluteTransform>();

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/PendingVictoryEffectSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/PendingVictoryEffectSystem.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics;
+using Arch.Buffer;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.Concept;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Concepts;
+using OpenSolarMax.Mods.Core.Systems.Timing;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, BeforeStructuralChanges]
+[Iterate(typeof(PendingVictoryEffect))]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class PendingVictoryEffectCountDownSystem(World world)
+    : CountDownSystemBase<PendingVictoryEffect>(world) { }
+
+[SimulateSystem, BeforeStructuralChanges]
+[ReadCurr(typeof(PendingVictoryEffect)), Write(typeof(ColonizationState)), ChangeStructure]
+[ExecuteBefore(typeof(ProgressColonizationSystem))]
+[ExecuteBefore(typeof(SettleColonizationSystem))]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class FirePendingVictoryEffectSystem(World world, IConceptFactory factory)
+    : ICalcSystemWithStructuralChanges
+{
+    [Query]
+    [All<PendingVictoryEffect>]
+    private void TriggerFire(
+        Entity pending,
+        in PendingVictoryEffect schedule,
+        [Data] CommandBuffer commandBuffer
+    )
+    {
+        if (schedule.TimeLeft > TimeSpan.Zero)
+            return;
+
+        var planet = schedule.Planet;
+        var winner = schedule.Winner;
+
+        // 创建 HaloExplosion 特效
+        var transform = planet.Get<AbsoluteTransform>();
+        var refSize = planet.Get<ReferenceSize>();
+
+        factory.Make(
+            world,
+            commandBuffer,
+            ConceptNames.HaloExplosion,
+            new HaloExplosionDescription
+            {
+                Color = winner.Get<TeamReferenceColor>().Value,
+                Position = transform.Translation,
+                PlanetRadius = refSize.Radius,
+            }
+        );
+
+        ref var affiliation = ref planet.Get<InTeam.AsAffiliate>();
+        if (affiliation.Relationship is null)
+        {
+            // 令中立天体立即加入获胜方
+            factory.Make(
+                world,
+                commandBuffer,
+                new InTeamDescription { Team = winner, Affiliate = planet }
+            );
+
+            // 重置 ColonizationState
+            ref var state = ref planet.Get<ColonizationState>();
+            state.Team = winner;
+            state.Progress = planet.Get<Colonizable>().Volume;
+            state.Event = ColonizationEvent.Idle;
+        }
+        else
+        {
+            // 如果非中立，只可能是胜利方阵营
+            Debug.Assert(affiliation.Relationship.Value.Copy.Team == winner);
+        }
+
+        // 销毁 pending 自身
+        commandBuffer.Destroy(pending);
+    }
+
+    public void Update(CommandBuffer commandBuffer) => TriggerFireQuery(world, commandBuffer);
+}

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/VictoryExitTimerSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/VictoryExitTimerSystem.cs
@@ -1,0 +1,50 @@
+using Arch.Buffer;
+using Arch.Core;
+using Arch.System;
+using Arch.System.SourceGenerator;
+using OpenSolarMax.Game.Modding.ECS;
+using OpenSolarMax.Game.Modding.UI;
+using OpenSolarMax.Mods.Core.Components;
+using OpenSolarMax.Mods.Core.Systems.Timing;
+
+namespace OpenSolarMax.Mods.Core.Systems;
+
+[SimulateSystem, BeforeStructuralChanges]
+[Iterate(typeof(VictoryExitTimer))]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class VictoryExitCountDownSystem(World world)
+    : CountDownSystemBase<VictoryExitTimer>(world) { }
+
+[SimulateSystem, BeforeStructuralChanges]
+[ReadCurr(typeof(VictoryExitTimer)), Write(typeof(GameState)), ChangeStructure]
+[ExecuteBefore(typeof(ApplyAnimationSystem))]
+public sealed partial class VictoryExitSystem(World world) : ICalcSystemWithStructuralChanges
+{
+    [Query]
+    [All<VictoryExitTimer>]
+    private static void CollectExpired(
+        Entity entity,
+        in VictoryExitTimer timer,
+        [Data] List<Entity> expired
+    )
+    {
+        if (timer.TimeLeft <= TimeSpan.Zero)
+            expired.Add(entity);
+    }
+
+    public void Update(CommandBuffer commandBuffer)
+    {
+        var expired = new List<Entity>();
+        CollectExpiredQuery(world, expired);
+        if (expired.Count == 0)
+            return;
+
+        world.Query(
+            new QueryDescription().WithAll<ViewTag, GameState>(),
+            (ref GameState state) => state.Status = GameStatus.Victory
+        );
+
+        foreach (var entity in expired)
+            commandBuffer.Destroy(entity);
+    }
+}

--- a/OpenSolarMax.Mods.Core/configs.toml
+++ b/OpenSolarMax.Mods.Core/configs.toml
@@ -1,3 +1,8 @@
+# 胜利判定相关
+
+[systems.victory]
+require_all_planets = false
+
 # 仿真系统相关
 
 [systems.simulate.jumping]

--- a/OpenSolarMax.Mods.Core/configs.toml
+++ b/OpenSolarMax.Mods.Core/configs.toml
@@ -2,6 +2,8 @@
 
 [systems.victory]
 require_all_planets = false
+wave_max_interval = 0.1          # 胜利波纹动效：星球间最大触发间隔，秒
+wave_total_seconds = 2.5          # 胜利波纹动效：从胜利帧起所有星球播完的总时长上限，秒
 
 # 仿真系统相关
 


### PR DESCRIPTION
**新增：**

- 关卡文件支持 `configs` 字段，覆盖模组 configs.toml 中的默认配置值。
- 关卡退出机制：通过组件通知游玩 GUI 视图退出。
- 胜利判定逻辑：只剩一支队伍且场上无敌方天体时判定该方胜利，或场上所有天体均为己方天体时判定胜利；二者可通过配置切换。
- 胜利后动画效果：所有星球按距几何中心由近到远依次触发，直接转为获胜方阵营，同步生成光环爆炸特效；并创建获胜方颜色的全屏遮罩逐渐淡出。
- 胜利一段时间后自动返回选关界面。

**注意：**

- 已观察到胜利最后一个占领的星球的动画和最终的胜利动画相互重叠，但解决该问题需要 ECS 架构重构，只得留作待办。