### PR TITLE
feat(modding): 丰富系统拓扑关系调试输出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,228 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+
+## .gitignore for Python project
+##
+## Get latest from https://github.com/github/gitignore/blob/main/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+*.lcov
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi/*
+!.pixi/config.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule*
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
+++ b/OpenSolarMax.Game/Level/LevelRuntimeLoader.cs
@@ -99,7 +99,7 @@ internal class LevelRuntimeLoader
         var world = World.Create();
         var inputSystem = new AggregateSystem(
             world,
-            _behaviors.SystemTypes.Input.Sorted,
+            _behaviors.SystemTypes.Input,
             new Dictionary<Type, object>
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
@@ -113,7 +113,7 @@ internal class LevelRuntimeLoader
         );
         var aiSystem = new AggregateSystem(
             world,
-            _behaviors.SystemTypes.Ai.Sorted,
+            _behaviors.SystemTypes.Ai,
             new Dictionary<Type, object>
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
@@ -127,7 +127,7 @@ internal class LevelRuntimeLoader
         );
         var simulateSystem = new AggregateSystem(
             world,
-            _behaviors.SystemTypes.Simulate.Sorted,
+            _behaviors.SystemTypes.Simulate,
             new Dictionary<Type, object>
             {
                 [typeof(IAssetsManager)] = _levelModContext.LocalAssets,
@@ -141,7 +141,7 @@ internal class LevelRuntimeLoader
         );
         var renderSystem = new AggregateSystem(
             world,
-            _behaviors.SystemTypes.Render.Sorted,
+            _behaviors.SystemTypes.Render,
             new Dictionary<Type, object>
             {
                 [typeof(GraphicsDevice)] = _game.GraphicsDevice,

--- a/OpenSolarMax.Game/Modding/BakedBehaviorsInfo.cs
+++ b/OpenSolarMax.Game/Modding/BakedBehaviorsInfo.cs
@@ -13,11 +13,12 @@ internal record BakedBehaviorsInfo(
     ImmutableDictionary<string, ImmutableArray<MethodInfo>> HookImplMethods
 )
 {
-    private static ImmutableSortedSystemTypes BakeSortedSystemTypes(IReadOnlySet<Type> systemTypes)
+    private static ImmutableArray<Type> BakeSortedSystemTypes(IReadOnlySet<Type> systemTypes)
     {
-        var orders = SystemsTopology.ExtractExecutionOrders(systemTypes);
+        var declarations = SystemsTopology.ExtractExecutionOrders(systemTypes);
+        var orders = SystemsTopology.ComposeExecutionGraph(declarations);
         var sorted = SystemsTopology.TopologicalSortSystems(systemTypes, orders);
-        return new ImmutableSortedSystemTypes([.. systemTypes], [.. orders], [.. sorted]);
+        return [.. sorted];
     }
 
     public static BakedBehaviorsInfo Bake(params BehaviorsInfo[] layers)

--- a/OpenSolarMax.Game/Modding/BakedBehaviorsInfo.cs
+++ b/OpenSolarMax.Game/Modding/BakedBehaviorsInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
 using OpenSolarMax.Game.Modding.Concept;
 using OpenSolarMax.Game.Modding.Declaration;
@@ -16,8 +17,15 @@ internal record BakedBehaviorsInfo(
     private static ImmutableArray<Type> BakeSortedSystemTypes(IReadOnlySet<Type> systemTypes)
     {
         var declarations = SystemsTopology.ExtractExecutionOrders(systemTypes);
-        var orders = SystemsTopology.ComposeExecutionGraph(declarations);
-        var sorted = SystemsTopology.TopologicalSortSystems(systemTypes, orders);
+        var edgeSources = SystemsTopology.ComposeExecutionGraph(declarations);
+        Debug.WriteLine("=== DOT GRAPH (for programmatic parsing) ===");
+        Debug.WriteLine(SystemsTopology.BuildSystemTopologyDotGraph(declarations, edgeSources));
+        Debug.WriteLine("=== D2 GRAPH (for visualization) ===");
+        Debug.WriteLine(SystemsTopology.BuildSystemTopologyD2Graph(declarations, edgeSources));
+        var sorted = SystemsTopology.TopologicalSortSystems(
+            systemTypes,
+            edgeSources.Keys.ToHashSet()
+        );
         return [.. sorted];
     }
 

--- a/OpenSolarMax.Game/Modding/ECS/SortedSystemTypeCollection.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SortedSystemTypeCollection.cs
@@ -1,8 +1,10 @@
+using System.Collections.Immutable;
+
 namespace OpenSolarMax.Game.Modding.ECS;
 
 internal record ImmutableSortedSystemTypeCollection(
-    ImmutableSortedSystemTypes Input,
-    ImmutableSortedSystemTypes Ai,
-    ImmutableSortedSystemTypes Simulate,
-    ImmutableSortedSystemTypes Render
+    ImmutableArray<Type> Input,
+    ImmutableArray<Type> Ai,
+    ImmutableArray<Type> Simulate,
+    ImmutableArray<Type> Render
 );

--- a/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
@@ -50,3 +50,11 @@ internal record SystemExecutionDeclarations(
     ImmutableHashSet<Type> ReactStageSystems,
     ImmutableHashSet<Type> AfterStageSystems
 );
+
+internal enum EdgeSource
+{
+    Explicit,
+    Priority,
+    ReadWrite,
+    StructuralChange,
+}

--- a/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
@@ -9,9 +9,6 @@ namespace OpenSolarMax.Game.Modding.ECS;
 /// <param name="After">要后执行的系统类型</param>
 internal record OrderedTypePair(Type Before, Type After)
 {
-    public override int GetHashCode() =>
-        HashCode.Combine(Before.GetHashCode(), After.GetHashCode());
-
     public OrderedTypePair Reverse() => new(After, Before);
 
     public UnorderedTypePair Unorder() => new(Before, After);

--- a/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SortedSystemTypes.cs
@@ -36,13 +36,17 @@ internal record UnorderedTypePair(Type Sys1, Type Sys2)
 }
 
 /// <summary>
-/// 包括执行顺序的系统类型
+/// 系统的执行声明集合，包括显式顺序、优先级、组件读写声明和执行阶段归属
 /// </summary>
-/// <param name="Types">所有系统类型</param>
-/// <param name="Orders">各个系统之间的执行顺序关系</param>
-/// <param name="Sorted">按照执行顺序要求完成排序的系统类型</param>
-internal record ImmutableSortedSystemTypes(
-    ImmutableHashSet<Type> Types,
-    ImmutableHashSet<OrderedTypePair> Orders,
-    ImmutableArray<Type> Sorted
+internal record SystemExecutionDeclarations(
+    ImmutableHashSet<OrderedTypePair> ExplicitOrders,
+    ImmutableHashSet<UnorderedTypePair> FineWithPairs,
+    ImmutableDictionary<Type, int> Priorities,
+    ImmutableDictionary<Type, ImmutableHashSet<Type>> PrevReaders,
+    ImmutableDictionary<Type, ImmutableHashSet<Type>> CurrReaders,
+    ImmutableDictionary<Type, ImmutableHashSet<Type>> Writers,
+    ImmutableDictionary<Type, ImmutableHashSet<Type>> Iterators,
+    ImmutableHashSet<Type> BeforeStageSystems,
+    ImmutableHashSet<Type> ReactStageSystems,
+    ImmutableHashSet<Type> AfterStageSystems
 );

--- a/OpenSolarMax.Game/Modding/ECS/SystemsTopology.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SystemsTopology.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -6,164 +7,166 @@ namespace OpenSolarMax.Game.Modding.ECS;
 
 internal static class SystemsTopology
 {
-    private static void RecordReadWriteAttribute<T>(
-        Type systemType,
-        Dictionary<Type, HashSet<Type>> record,
-        HashSet<Type> alls
-    )
-        where T : Attribute, IReadWriteAttribute
-    {
-        foreach (var attribute in systemType.GetCustomAttributes<T>())
-        {
-            if (attribute.Type == typeof(AllComponents))
-                alls.Add(systemType);
-            else if (record.TryGetValue(attribute.Type, out var readers))
-                readers.Add(systemType);
-            else
-                record.Add(attribute.Type, [systemType]);
-        }
-    }
-
     /// <summary>
-    /// 计算系统之间的相对顺序
+    /// 纯提取原始拓扑声明
     /// </summary>
     /// <param name="systemTypes">所有系统类型</param>
-    /// <returns>一个集合，记录了所有代码中声明了的执行顺序关系</returns>
-    public static HashSet<OrderedTypePair> ExtractExecutionOrders(IReadOnlySet<Type> systemTypes)
+    /// <returns>系统的执行声明集合，包含显式顺序、优先级、组件读写声明和执行阶段归属</returns>
+    public static SystemExecutionDeclarations ExtractExecutionOrders(IReadOnlySet<Type> systemTypes)
     {
-        #region 显式执行顺序关系提取、检查与合并
-
         // 显式执行顺序
         var explicitOrders = new HashSet<OrderedTypePair>();
-        var explicitFinePairs = new HashSet<UnorderedTypePair>();
+        var fineWithPairs = new HashSet<UnorderedTypePair>();
 
-        // 优先级分组
-        var priorityGroups = new SortedDictionary<int, HashSet<Type>>();
+        // 优先级
+        var priorities = new Dictionary<Type, int>();
+
+        // 组件的读写记录
+        var prevReaders = new Dictionary<Type, HashSet<Type>>();
+        var currReaders = new Dictionary<Type, HashSet<Type>>();
+        var writers = new Dictionary<Type, HashSet<Type>>();
+        var iterators = new Dictionary<Type, HashSet<Type>>();
+
+        // 系统的执行阶段
+        var beforeSystems = new HashSet<Type>();
+        var reactSystems = new HashSet<Type>();
+        var afterSystems = new HashSet<Type>();
 
         foreach (var systemType in systemTypes)
         {
             // 检查 ExecuteAfter 属性
-            var executeAfterAttributes = systemType.GetCustomAttributes<ExecuteAfterAttribute>();
-            foreach (var executeAfterAttribute in executeAfterAttributes)
-            {
-                if (systemTypes.Contains(executeAfterAttribute.TheOther))
-                    explicitOrders.Add(
-                        new OrderedTypePair(executeAfterAttribute.TheOther, systemType)
-                    );
-            }
+            foreach (var attr in systemType.GetCustomAttributes<ExecuteAfterAttribute>())
+                if (systemTypes.Contains(attr.TheOther))
+                    explicitOrders.Add(new OrderedTypePair(attr.TheOther, systemType));
 
             // 检查 ExecuteBefore 属性
-            var executeBeforeAttributes = systemType.GetCustomAttributes<ExecuteBeforeAttribute>();
-            foreach (var executeBeforeAttribute in executeBeforeAttributes)
-            {
-                if (systemTypes.Contains(executeBeforeAttribute.TheOther))
-                    explicitOrders.Add(
-                        new OrderedTypePair(systemType, executeBeforeAttribute.TheOther)
-                    );
-            }
+            foreach (var attr in systemType.GetCustomAttributes<ExecuteBeforeAttribute>())
+                if (systemTypes.Contains(attr.TheOther))
+                    explicitOrders.Add(new OrderedTypePair(systemType, attr.TheOther));
 
             // 检查 FineWith 属性
-            var fineWithAttributes = systemType.GetCustomAttributes<FineWithAttribute>();
-            foreach (var fineWithAttribute in fineWithAttributes)
-                explicitFinePairs.Add(
-                    new UnorderedTypePair(systemType, fineWithAttribute.TheOther)
-                );
+            foreach (var attr in systemType.GetCustomAttributes<FineWithAttribute>())
+                fineWithPairs.Add(new UnorderedTypePair(systemType, attr.TheOther));
 
             // 检查 Priority 属性
-            var priorityAttribute = systemType
-                .GetCustomAttributes<PriorityAttribute>()
-                .FirstOrDefault();
-            if (priorityAttribute is not null)
+            var priorityAttr = systemType.GetCustomAttributes<PriorityAttribute>().FirstOrDefault();
+            if (priorityAttr is not null)
+                priorities[systemType] = priorityAttr.Value;
+
+            // 记录读写属性
+            foreach (var attr in systemType.GetCustomAttributes<ReadPrevAttribute>())
             {
-                if (priorityGroups.TryGetValue(priorityAttribute.Value, out var group))
-                    group.Add(systemType);
-                else
-                    priorityGroups.Add(priorityAttribute.Value, [systemType]);
+                if (!prevReaders.TryGetValue(attr.Type, out var set))
+                    prevReaders[attr.Type] = set = [];
+                set.Add(systemType);
             }
-            // TODO: 是否支持默认优先级？
-        }
-
-        // 检测同一对系统是否有多个相互矛盾的显式关系
-        foreach (
-            var group in explicitOrders.ToLookup(
-                p => new UnorderedTypePair(p.Before, p.After),
-                p => p
-            )
-        )
-        {
-            if (group.Count() > 1 || explicitFinePairs.Contains(group.Key))
-                throw new Exception(
-                    "Conflicted explicit execution order"
-                        + $"between {group.Key.Sys1} and {group.Key.Sys2}"
-                );
-        }
-
-        // 检测同一个系统是否位于多个优先级
-        // 由于优先级属性禁止设置多个，因此此处无须检查
-
-        // 合并优先级关系。优先级关系和显式执行顺序的权重相同，因此直接添加。若构成环则等到排序时再发现
-        foreach (var (priority1, group1) in priorityGroups)
-        {
-            foreach (var (priority2, group2) in priorityGroups.Reverse()) // 从大到小
+            foreach (var attr in systemType.GetCustomAttributes<ReadCurrAttribute>())
             {
-                if (priority2 <= priority1)
-                    break; // 当访问到第一个比自己优先级相同或低的就结束遍历
-
-                explicitOrders.UnionWith(
-                    from sys1 in group1
-                    from sys2 in group2
-                    select new OrderedTypePair(sys1, sys2) // 高优先级的系统更靠后执行
-                );
+                if (!currReaders.TryGetValue(attr.Type, out var set))
+                    currReaders[attr.Type] = set = [];
+                set.Add(systemType);
             }
+            foreach (var attr in systemType.GetCustomAttributes<WriteAttribute>())
+            {
+                if (!writers.TryGetValue(attr.Type, out var set))
+                    writers[attr.Type] = set = [];
+                set.Add(systemType);
+            }
+            foreach (var attr in systemType.GetCustomAttributes<IterateAttribute>())
+            {
+                if (!iterators.TryGetValue(attr.Type, out var set))
+                    iterators[attr.Type] = set = [];
+                set.Add(systemType);
+            }
+
+            // 记录系统阶段
+            if (systemType.GetCustomAttributes<BeforeStructuralChangesAttribute>().Any())
+                beforeSystems.Add(systemType);
+            else if (systemType.GetCustomAttributes<ReactToStructuralChangesAttribute>().Any())
+                reactSystems.Add(systemType);
+            else if (systemType.GetCustomAttributes<AfterStructuralChangesAttribute>().Any())
+                afterSystems.Add(systemType);
         }
 
-        // 检查显式关系有无自相矛盾
-        foreach (
-            var group in explicitOrders.ToLookup(
-                p => new UnorderedTypePair(p.Before, p.After),
-                p => p
-            )
-        )
+        return new SystemExecutionDeclarations(
+            ExplicitOrders: explicitOrders.ToImmutableHashSet(),
+            FineWithPairs: fineWithPairs.ToImmutableHashSet(),
+            Priorities: priorities.ToImmutableDictionary(),
+            PrevReaders: prevReaders.ToImmutableDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToImmutableHashSet()
+            ),
+            CurrReaders: currReaders.ToImmutableDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToImmutableHashSet()
+            ),
+            Writers: writers.ToImmutableDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToImmutableHashSet()
+            ),
+            Iterators: iterators.ToImmutableDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToImmutableHashSet()
+            ),
+            BeforeStageSystems: beforeSystems.ToImmutableHashSet(),
+            ReactStageSystems: reactSystems.ToImmutableHashSet(),
+            AfterStageSystems: afterSystems.ToImmutableHashSet()
+        );
+    }
+
+    /// <summary>
+    /// 组合执行图：基于提取的系统执行声明进行验证、推导与合并，产出最终执行顺序关系图
+    /// </summary>
+    /// <param name="declarations">从系统类型属性中提取的原始声明</param>
+    /// <returns>最终的执行顺序关系集合</returns>
+    public static HashSet<OrderedTypePair> ComposeExecutionGraph(
+        SystemExecutionDeclarations declarations
+    )
+    {
+        #region 推导所有系统类型
+
+        var systemTypes = new HashSet<Type>();
+        foreach (var (before, after) in declarations.ExplicitOrders)
         {
-            if (group.Count() > 1)
-                throw new Exception(
-                    $"Conflicted strong execution order between {group.Key.Sys1} and {group.Key.Sys2}"
-                );
+            systemTypes.Add(before);
+            systemTypes.Add(after);
+        }
+        foreach (var sysType in declarations.Priorities.Keys)
+            systemTypes.Add(sysType);
+        foreach (var (_, readers) in declarations.PrevReaders)
+            systemTypes.UnionWith(readers);
+        foreach (var (_, readers) in declarations.CurrReaders)
+            systemTypes.UnionWith(readers);
+        foreach (var (_, writers) in declarations.Writers)
+            systemTypes.UnionWith(writers);
+        foreach (var (_, iterators) in declarations.Iterators)
+            systemTypes.UnionWith(iterators);
+        systemTypes.UnionWith(declarations.BeforeStageSystems);
+        systemTypes.UnionWith(declarations.ReactStageSystems);
+        systemTypes.UnionWith(declarations.AfterStageSystems);
+        foreach (var pair in declarations.FineWithPairs)
+        {
+            systemTypes.Add(pair.Sys1);
+            systemTypes.Add(pair.Sys2);
         }
 
         #endregion
 
-        #region 读写操作关系提取、检查与合并
-
-        // 组件的读写记录
-        var prevComponentsReaders = new Dictionary<Type, HashSet<Type>>();
-        var newComponentsReaders = new Dictionary<Type, HashSet<Type>>();
-        var componentsWriters = new Dictionary<Type, HashSet<Type>>();
-        var componentsIterators = new Dictionary<Type, HashSet<Type>>();
-        var allPrevComponentsReaders = new HashSet<Type>();
-        var allNewComponentsReaders = new HashSet<Type>();
-        var allComponentsWriters = new HashSet<Type>();
-        var allComponentsIterators = new HashSet<Type>();
-
-        // 系统的执行阶段
-        var beforeStructuralChangesSystems = new HashSet<Type>();
-        var reactToStructuralChangesSystems = new HashSet<Type>();
-        var afterStructuralChangesSystems = new HashSet<Type>();
+        #region 单系统验证
 
         foreach (var systemType in systemTypes)
         {
-            // 检查单个系统所有属性是否满足规则：
-
-            // > 禁止同时 Read/Write 同一个组件
-            if (
-                Enumerable
-                    .Concat(
-                        systemType.GetCustomAttributes<ReadPrevAttribute>().Select(a => a.Type),
-                        systemType.GetCustomAttributes<ReadCurrAttribute>().Select(a => a.Type)
-                    )
-                    .Intersect(systemType.GetCustomAttributes<WriteAttribute>().Select(a => a.Type))
-                    .Any()
-            )
+            // > 禁止同时 Read/Write 同一个组件（使用 declarations 中的读写数据）
+            var readsPrev = declarations
+                .PrevReaders.Where(kvp => kvp.Value.Contains(systemType))
+                .Select(kvp => kvp.Key);
+            var readsCurr = declarations
+                .CurrReaders.Where(kvp => kvp.Value.Contains(systemType))
+                .Select(kvp => kvp.Key);
+            var writes = declarations
+                .Writers.Where(kvp => kvp.Value.Contains(systemType))
+                .Select(kvp => kvp.Key);
+            if (readsPrev.Concat(readsCurr).Intersect(writes).Any())
                 throw new Exception("A system shall not read and write the same component!");
 
             // > 有且只有一个执行阶段属性
@@ -179,14 +182,11 @@ internal static class SystemsTopology
             else if (systemType.GetCustomAttributes<ReactToStructuralChangesAttribute>().Any()) { }
             else if (systemType.GetCustomAttributes<AfterStructuralChangesAttribute>().Any())
             {
-                // 结构化变更之后的系统禁止产生结构化变更
                 if (systemType.GetCustomAttributes<ChangeStructureAttribute>().Any())
                     throw new Exception(
                         "A after-structural-changes system shall not make structural changes!"
                     );
             }
-
-            // 检查属性和接口是否匹配
 
             // > 声明了结构化变更的系统必须继承 IXxxSystemWithStructuralChanges；反之亦然
             if (
@@ -230,43 +230,112 @@ internal static class SystemsTopology
                 throw new Exception(
                     $"{systemType} shall implement exactly one interface among: {expectedInterfaces}"
                 );
-
-            // 记录属性
-            RecordReadWriteAttribute<ReadPrevAttribute>(
-                systemType,
-                prevComponentsReaders,
-                allPrevComponentsReaders
-            );
-            RecordReadWriteAttribute<ReadCurrAttribute>(
-                systemType,
-                newComponentsReaders,
-                allNewComponentsReaders
-            );
-            RecordReadWriteAttribute<IterateAttribute>(
-                systemType,
-                componentsIterators,
-                allComponentsIterators
-            );
-            RecordReadWriteAttribute<WriteAttribute>(
-                systemType,
-                componentsWriters,
-                allComponentsWriters
-            );
-
-            // 记录系统阶段
-            if (systemType.GetCustomAttributes<BeforeStructuralChangesAttribute>().Any())
-                beforeStructuralChangesSystems.Add(systemType);
-            else if (systemType.GetCustomAttributes<ReactToStructuralChangesAttribute>().Any())
-                reactToStructuralChangesSystems.Add(systemType);
-            else if (systemType.GetCustomAttributes<AfterStructuralChangesAttribute>().Any())
-                afterStructuralChangesSystems.Add(systemType);
         }
+
+        #endregion
+
+        #region 显式执行顺序关系检查与合并
+
+        var explicitOrders = declarations.ExplicitOrders.ToHashSet();
+        var explicitFinePairs = declarations.FineWithPairs.ToHashSet();
+
+        // 检测同一对系统是否有多个相互矛盾的显式关系
+        foreach (
+            var group in explicitOrders.ToLookup(
+                p => new UnorderedTypePair(p.Before, p.After),
+                p => p
+            )
+        )
+        {
+            if (group.Count() > 1 || explicitFinePairs.Contains(group.Key))
+                throw new Exception(
+                    "Conflicted explicit execution order"
+                        + $"between {group.Key.Sys1} and {group.Key.Sys2}"
+                );
+        }
+
+        // 合并优先级关系
+        var priorityGroups = new SortedDictionary<int, HashSet<Type>>();
+        foreach (var (sysType, priority) in declarations.Priorities)
+        {
+            if (priorityGroups.TryGetValue(priority, out var group))
+                group.Add(sysType);
+            else
+                priorityGroups.Add(priority, [sysType]);
+        }
+
+        foreach (var (priority1, group1) in priorityGroups)
+        {
+            foreach (var (priority2, group2) in priorityGroups.Reverse())
+            {
+                if (priority2 <= priority1)
+                    break;
+
+                explicitOrders.UnionWith(
+                    from sys1 in group1
+                    from sys2 in group2
+                    select new OrderedTypePair(sys1, sys2)
+                );
+            }
+        }
+
+        // 检查显式关系有无自相矛盾
+        foreach (
+            var group in explicitOrders.ToLookup(
+                p => new UnorderedTypePair(p.Before, p.After),
+                p => p
+            )
+        )
+        {
+            if (group.Count() > 1)
+                throw new Exception(
+                    $"Conflicted strong execution order between {group.Key.Sys1} and {group.Key.Sys2}"
+                );
+        }
+
+        #endregion
+
+        #region 读写操作关系合并、检查与推导
+
+        // 构建可变的读写字典
+        var prevComponentsReaders = declarations.PrevReaders.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.ToHashSet()
+        );
+        var newComponentsReaders = declarations.CurrReaders.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.ToHashSet()
+        );
+        var componentsWriters = declarations.Writers.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.ToHashSet()
+        );
+        var componentsIterators = declarations.Iterators.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.ToHashSet()
+        );
+
+        // 提取并移除 AllComponents 条目
+        var allPrevReaders = prevComponentsReaders.TryGetValue(typeof(AllComponents), out var apr)
+            ? apr
+            : [];
+        prevComponentsReaders.Remove(typeof(AllComponents));
+        var allNewReaders = newComponentsReaders.TryGetValue(typeof(AllComponents), out var anr)
+            ? anr
+            : [];
+        newComponentsReaders.Remove(typeof(AllComponents));
+        var allWriters = componentsWriters.TryGetValue(typeof(AllComponents), out var aw) ? aw : [];
+        componentsWriters.Remove(typeof(AllComponents));
+        var allIterators = componentsIterators.TryGetValue(typeof(AllComponents), out var ai)
+            ? ai
+            : [];
+        componentsIterators.Remove(typeof(AllComponents));
 
         // 将任意组件读写系统并入其他关系
         foreach (var (_, readers) in prevComponentsReaders)
-            readers.UnionWith(allPrevComponentsReaders);
+            readers.UnionWith(allPrevReaders);
         foreach (var (_, readers) in newComponentsReaders)
-            readers.UnionWith(allNewComponentsReaders);
+            readers.UnionWith(allNewReaders);
 
         var componentsEditors = componentsWriters
             .Concat(componentsIterators)
@@ -276,21 +345,19 @@ internal static class SystemsTopology
                 g.SelectMany(p => p.Value).ToHashSet()
             ))
             .ToDictionary();
-        var allComponentsEditors = allComponentsWriters.Union(allComponentsIterators).ToHashSet();
+        var allComponentsEditors = allWriters.Union(allIterators).ToHashSet();
 
         foreach (var (_, editors) in componentsEditors)
-            editors.UnionWith(allComponentsWriters.Union(allComponentsEditors));
+            editors.UnionWith(allComponentsEditors);
 
         // 检测同一个组件是否有多个 Writer 或 Iterator
-
-        foreach (var (_, editors) in componentsEditors.Where(p => p.Value.Count >= 1))
+        foreach (var (_, editors) in componentsEditors)
         {
-            // 多个 Writer 或 Iterator 之间必须两两显式声明执行顺序先后或者无关
             foreach (
                 var (editor1, editor2) in from w1 in editors
                 from w2 in editors.Where(w => w != w1)
                 select (w1, w2)
-            ) // TODO: 有重复
+            )
             {
                 if (
                     !explicitOrders.Contains(new OrderedTypePair(editor1, editor2))
@@ -306,7 +373,6 @@ internal static class SystemsTopology
         // 计算读写组件的顺序
         var readWriteOrders = new HashSet<OrderedTypePair>();
 
-        // ReadPrev 在所有 Write 和 Iterate 之前执行
         foreach (var (componentType, readers) in prevComponentsReaders)
         {
             if (!componentsEditors.TryGetValue(componentType, out var editors))
@@ -319,7 +385,6 @@ internal static class SystemsTopology
             );
         }
 
-        // ReadNew 在所有 Write 和 Iterate 之后执行
         foreach (var (componentType, readers) in newComponentsReaders)
         {
             if (!componentsEditors.TryGetValue(componentType, out var editors))
@@ -332,20 +397,28 @@ internal static class SystemsTopology
             );
         }
 
+        #endregion
+
+        #region 结构化变更阶段顺序推导
+
+        var beforeSystems = declarations.BeforeStageSystems.ToHashSet();
+        var reactSystems = declarations.ReactStageSystems.ToHashSet();
+        var afterSystems = declarations.AfterStageSystems.ToHashSet();
+
         var structuralChangeOrders = new HashSet<OrderedTypePair>();
         structuralChangeOrders.UnionWith(
-            from before in beforeStructuralChangesSystems
-            from after in reactToStructuralChangesSystems
+            from before in beforeSystems
+            from after in reactSystems
             select new OrderedTypePair(before, after)
         );
         structuralChangeOrders.UnionWith(
-            from before in beforeStructuralChangesSystems
-            from after in afterStructuralChangesSystems
+            from before in beforeSystems
+            from after in afterSystems
             select new OrderedTypePair(before, after)
         );
         structuralChangeOrders.UnionWith(
-            from before in reactToStructuralChangesSystems
-            from after in afterStructuralChangesSystems
+            from before in reactSystems
+            from after in afterSystems
             select new OrderedTypePair(before, after)
         );
 
@@ -354,43 +427,24 @@ internal static class SystemsTopology
         // 以显式顺序为基础
         var finalOrders = explicitOrders.ToHashSet();
 
-        // 添加所有组件读写关系。若组件读写关系与显式顺序冲突，以显式顺序为准；但是若组件读写顺序与结构化变更顺序冲突，需要暴露
+        // 添加所有组件读写关系
         finalOrders.UnionWith(
             readWriteOrders.Where(p =>
                 !explicitOrders.Contains(p.Reverse()) && !explicitFinePairs.Contains(p.Unorder())
             )
         );
 
-        // 构建 graphviz 文本
-        var dotsBuilder = new StringBuilder();
-        dotsBuilder.AppendLine("strict digraph {");
-        dotsBuilder.AppendLine("  rankdir=LR;");
-        // 添加三个阶段
-        dotsBuilder.AppendLine("  subgraph BeforeStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"BeforeStructuralChanges\"");
-        foreach (var system in beforeStructuralChangesSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        dotsBuilder.AppendLine("  subgraph ReactToStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"ReactToStructuralChanges\"");
-        foreach (var system in reactToStructuralChangesSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        dotsBuilder.AppendLine("  subgraph AfterStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"AfterStructuralChanges\"");
-        foreach (var system in afterStructuralChangesSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        // 添加依赖关系
-        foreach (var (before, after) in finalOrders)
-            dotsBuilder.AppendLine($"  \"{after.Name}\" -> \"{before.Name}\";");
-        dotsBuilder.AppendLine("}");
-        Debug.WriteLine(dotsBuilder.ToString());
+        // 构建并输出 graphviz 文本
+        var dotGraph = BuildSystemTopologyDotGraph(
+            systemTypes,
+            finalOrders,
+            beforeSystems,
+            reactSystems,
+            afterSystems
+        );
+        Debug.WriteLine(dotGraph);
 
-        // 添加所有结构化变更阶段关系。若结构化变更关系与显式关系冲突，需要在拓扑排序时暴露
+        // 添加所有结构化变更阶段关系
         finalOrders.UnionWith(structuralChangeOrders);
 
         return finalOrders;
@@ -439,5 +493,45 @@ internal static class SystemsTopology
         }
 
         return systems;
+    }
+
+    /// <summary>
+    /// 构建系统拓扑的 Graphviz DOT 格式文本
+    /// </summary>
+    public static string BuildSystemTopologyDotGraph(
+        IReadOnlySet<Type> systemTypes,
+        IReadOnlySet<OrderedTypePair> orders,
+        IReadOnlySet<Type> beforeSystems,
+        IReadOnlySet<Type> reactSystems,
+        IReadOnlySet<Type> afterSystems
+    )
+    {
+        var dotsBuilder = new StringBuilder();
+        dotsBuilder.AppendLine("strict digraph {");
+        dotsBuilder.AppendLine("  rankdir=LR;");
+        // 添加三个阶段
+        dotsBuilder.AppendLine("  subgraph BeforeStructuralChanges {");
+        dotsBuilder.AppendLine("    cluster=true;");
+        dotsBuilder.AppendLine("    label=\"BeforeStructuralChanges\"");
+        foreach (var system in beforeSystems)
+            dotsBuilder.AppendLine($"    \"{system.Name}\";");
+        dotsBuilder.AppendLine("  }");
+        dotsBuilder.AppendLine("  subgraph ReactToStructuralChanges {");
+        dotsBuilder.AppendLine("    cluster=true;");
+        dotsBuilder.AppendLine("    label=\"ReactToStructuralChanges\"");
+        foreach (var system in reactSystems)
+            dotsBuilder.AppendLine($"    \"{system.Name}\";");
+        dotsBuilder.AppendLine("  }");
+        dotsBuilder.AppendLine("  subgraph AfterStructuralChanges {");
+        dotsBuilder.AppendLine("    cluster=true;");
+        dotsBuilder.AppendLine("    label=\"AfterStructuralChanges\"");
+        foreach (var system in afterSystems)
+            dotsBuilder.AppendLine($"    \"{system.Name}\";");
+        dotsBuilder.AppendLine("  }");
+        // 添加依赖关系
+        foreach (var (before, after) in orders)
+            dotsBuilder.AppendLine($"  \"{after.Name}\" -> \"{before.Name}\";");
+        dotsBuilder.AppendLine("}");
+        return dotsBuilder.ToString();
     }
 }

--- a/OpenSolarMax.Game/Modding/ECS/SystemsTopology.cs
+++ b/OpenSolarMax.Game/Modding/ECS/SystemsTopology.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
@@ -115,14 +114,24 @@ internal static class SystemsTopology
     }
 
     /// <summary>
-    /// 组合执行图：基于提取的系统执行声明进行验证、推导与合并，产出最终执行顺序关系图
+    /// 组合执行图：基于提取的系统执行声明进行验证、推导与合并，产出最终执行顺序关系集合，并为每条边标注来源
     /// </summary>
     /// <param name="declarations">从系统类型属性中提取的原始声明</param>
-    /// <returns>最终的执行顺序关系集合</returns>
-    public static HashSet<OrderedTypePair> ComposeExecutionGraph(
+    /// <returns>所有系统之间的执行顺序关系，每个键为有序对，每个值为该边来源集合</returns>
+    public static Dictionary<OrderedTypePair, HashSet<EdgeSource>> ComposeExecutionGraph(
         SystemExecutionDeclarations declarations
     )
     {
+        var edgeSources = new Dictionary<OrderedTypePair, HashSet<EdgeSource>>();
+
+        void RegisterEdge(OrderedTypePair pair, EdgeSource src)
+        {
+            if (edgeSources.TryGetValue(pair, out var sources))
+                sources.Add(src);
+            else
+                edgeSources[pair] = new HashSet<EdgeSource> { src };
+        }
+
         #region 推导所有系统类型
 
         var systemTypes = new HashSet<Type>();
@@ -178,15 +187,13 @@ internal static class SystemsTopology
             )
                 throw new Exception("A system shall belong to exactly one stage!");
 
-            if (systemType.GetCustomAttributes<BeforeStructuralChangesAttribute>().Any()) { }
-            else if (systemType.GetCustomAttributes<ReactToStructuralChangesAttribute>().Any()) { }
-            else if (systemType.GetCustomAttributes<AfterStructuralChangesAttribute>().Any())
-            {
-                if (systemType.GetCustomAttributes<ChangeStructureAttribute>().Any())
-                    throw new Exception(
-                        "A after-structural-changes system shall not make structural changes!"
-                    );
-            }
+            if (
+                systemType.GetCustomAttributes<AfterStructuralChangesAttribute>().Any()
+                && systemType.GetCustomAttributes<ChangeStructureAttribute>().Any()
+            )
+                throw new Exception(
+                    "A after-structural-changes system shall not make structural changes!"
+                );
 
             // > 声明了结构化变更的系统必须继承 IXxxSystemWithStructuralChanges；反之亦然
             if (
@@ -237,6 +244,8 @@ internal static class SystemsTopology
         #region 显式执行顺序关系检查与合并
 
         var explicitOrders = declarations.ExplicitOrders.ToHashSet();
+        foreach (var pair in explicitOrders)
+            RegisterEdge(pair, EdgeSource.Explicit);
         var explicitFinePairs = declarations.FineWithPairs.ToHashSet();
 
         // 检测同一对系统是否有多个相互矛盾的显式关系
@@ -271,11 +280,9 @@ internal static class SystemsTopology
                 if (priority2 <= priority1)
                     break;
 
-                explicitOrders.UnionWith(
-                    from sys1 in group1
-                    from sys2 in group2
-                    select new OrderedTypePair(sys1, sys2)
-                );
+                foreach (var sys1 in group1)
+                foreach (var sys2 in group2)
+                    RegisterEdge(new OrderedTypePair(sys1, sys2), EdgeSource.Priority);
             }
         }
 
@@ -424,30 +431,23 @@ internal static class SystemsTopology
 
         #endregion
 
-        // 以显式顺序为基础
-        var finalOrders = explicitOrders.ToHashSet();
-
         // 添加所有组件读写关系
-        finalOrders.UnionWith(
-            readWriteOrders.Where(p =>
+        foreach (
+            var p in readWriteOrders.Where(p =>
                 !explicitOrders.Contains(p.Reverse()) && !explicitFinePairs.Contains(p.Unorder())
             )
-        );
-
-        // 构建并输出 graphviz 文本
-        var dotGraph = BuildSystemTopologyDotGraph(
-            systemTypes,
-            finalOrders,
-            beforeSystems,
-            reactSystems,
-            afterSystems
-        );
-        Debug.WriteLine(dotGraph);
+        )
+        {
+            RegisterEdge(p, EdgeSource.ReadWrite);
+        }
 
         // 添加所有结构化变更阶段关系
-        finalOrders.UnionWith(structuralChangeOrders);
+        foreach (var p in structuralChangeOrders)
+        {
+            RegisterEdge(p, EdgeSource.StructuralChange);
+        }
 
-        return finalOrders;
+        return edgeSources;
     }
 
     /// <summary>
@@ -496,42 +496,147 @@ internal static class SystemsTopology
     }
 
     /// <summary>
-    /// 构建系统拓扑的 Graphviz DOT 格式文本
+    /// 构建系统拓扑的 Graphviz DOT 格式文本，用于程序解析。节点带 stage/priority 属性，边带来源 label。
     /// </summary>
+    /// <param name="declarations">系统执行声明</param>
+    /// <param name="edgeSources">所有系统之间的执行顺序关系，每个键为有序对，每个值为该边来源集合</param>
     public static string BuildSystemTopologyDotGraph(
-        IReadOnlySet<Type> systemTypes,
-        IReadOnlySet<OrderedTypePair> orders,
-        IReadOnlySet<Type> beforeSystems,
-        IReadOnlySet<Type> reactSystems,
-        IReadOnlySet<Type> afterSystems
+        SystemExecutionDeclarations declarations,
+        Dictionary<OrderedTypePair, HashSet<EdgeSource>> edgeSources
     )
     {
         var dotsBuilder = new StringBuilder();
         dotsBuilder.AppendLine("strict digraph {");
         dotsBuilder.AppendLine("  rankdir=LR;");
-        // 添加三个阶段
-        dotsBuilder.AppendLine("  subgraph BeforeStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"BeforeStructuralChanges\"");
-        foreach (var system in beforeSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        dotsBuilder.AppendLine("  subgraph ReactToStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"ReactToStructuralChanges\"");
-        foreach (var system in reactSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        dotsBuilder.AppendLine("  subgraph AfterStructuralChanges {");
-        dotsBuilder.AppendLine("    cluster=true;");
-        dotsBuilder.AppendLine("    label=\"AfterStructuralChanges\"");
-        foreach (var system in afterSystems)
-            dotsBuilder.AppendLine($"    \"{system.Name}\";");
-        dotsBuilder.AppendLine("  }");
-        // 添加依赖关系
-        foreach (var (before, after) in orders)
-            dotsBuilder.AppendLine($"  \"{after.Name}\" -> \"{before.Name}\";");
+
+        // 节点声明: 所有系统 type, 标注 stage 和 priority
+        var allSystems = declarations
+            .BeforeStageSystems.Union(declarations.ReactStageSystems)
+            .Union(declarations.AfterStageSystems);
+        foreach (var type in allSystems)
+        {
+            string stage;
+            if (declarations.BeforeStageSystems.Contains(type))
+                stage = "before";
+            else if (declarations.ReactStageSystems.Contains(type))
+                stage = "react";
+            else
+                stage = "after";
+
+            if (declarations.Priorities.TryGetValue(type, out var priority))
+                dotsBuilder.AppendLine($"  \"{type.Name}\" [stage={stage}, priority={priority}];");
+            else
+                dotsBuilder.AppendLine($"  \"{type.Name}\" [stage={stage}];");
+        }
+
+        // 边声明: 遍历所有 edgeSources, 带来源 label, after -> before
+        foreach (var (pair, sources) in edgeSources)
+        {
+            var label = string.Join(
+                ";",
+                sources.OrderBy(s => s).Select(s => s.ToString().ToLowerInvariant())
+            );
+            dotsBuilder.AppendLine(
+                $"  \"{pair.After.Name}\" -> \"{pair.Before.Name}\" [label=\"{label}\"];"
+            );
+        }
+
         dotsBuilder.AppendLine("}");
         return dotsBuilder.ToString();
+    }
+
+    /// <summary>
+    /// 构建系统拓扑的 D2 格式文本，用于可视化。阶段用容器表示，结构变更用容器间宏边，过滤掉 Priority 和 StructuralChange 来源边。
+    /// </summary>
+    /// <param name="declarations">系统执行声明</param>
+    /// <param name="edgeSources">所有系统之间的执行顺序关系，每个键为有序对，每个值为该边来源集合</param>
+    public static string BuildSystemTopologyD2Graph(
+        SystemExecutionDeclarations declarations,
+        Dictionary<OrderedTypePair, HashSet<EdgeSource>> edgeSources
+    )
+    {
+        var d2Builder = new StringBuilder();
+        d2Builder.AppendLine("direction: left");
+        d2Builder.AppendLine();
+
+        // 3 个 stage 容器, 内嵌 priority 子容器
+        void WriteStageContainer(string name, IReadOnlySet<Type> types)
+        {
+            d2Builder.AppendLine($"{name}: {{");
+            // 按 priority 分组
+            var byPriority = types
+                .GroupBy(t => declarations.Priorities.TryGetValue(t, out var p) ? (int?)p : null)
+                .OrderByDescending(g => g.Key ?? int.MinValue);
+            foreach (var group in byPriority)
+            {
+                if (group.Key.HasValue)
+                {
+                    d2Builder.AppendLine($"  priority_{group.Key}: {{");
+                    foreach (var type in group)
+                        d2Builder.AppendLine($"    {type.Name}");
+                    d2Builder.AppendLine("  }");
+                }
+                else
+                {
+                    foreach (var type in group)
+                        d2Builder.AppendLine($"  {type.Name}");
+                }
+            }
+            d2Builder.AppendLine("}");
+            d2Builder.AppendLine();
+        }
+        WriteStageContainer("BeforeStructuralChanges", declarations.BeforeStageSystems);
+        WriteStageContainer("ReactToStructuralChanges", declarations.ReactStageSystems);
+        WriteStageContainer("AfterStructuralChanges", declarations.AfterStageSystems);
+
+        // 3 条 cluster 间宏边
+        d2Builder.AppendLine(
+            "ReactToStructuralChanges -> BeforeStructuralChanges: structuralChange"
+        );
+        d2Builder.AppendLine("AfterStructuralChanges -> BeforeStructuralChanges: structuralChange");
+        d2Builder.AppendLine(
+            "AfterStructuralChanges -> ReactToStructuralChanges: structuralChange"
+        );
+        d2Builder.AppendLine();
+
+        // 遍历 edgeSources, 过滤掉 Priority 和 StructuralChange 来源
+        foreach (var (pair, sources) in edgeSources)
+        {
+            var remaining = sources
+                .Where(s => s != EdgeSource.Priority && s != EdgeSource.StructuralChange)
+                .ToHashSet();
+            if (remaining.Count == 0)
+                continue;
+
+            var afterStage =
+                declarations.BeforeStageSystems.Contains(pair.After) ? 0
+                : declarations.ReactStageSystems.Contains(pair.After) ? 1
+                : 2;
+            var beforeStage =
+                declarations.BeforeStageSystems.Contains(pair.Before) ? 0
+                : declarations.ReactStageSystems.Contains(pair.Before) ? 1
+                : 2;
+            if (afterStage != beforeStage)
+                continue;
+
+            var label = string.Join(
+                ";",
+                remaining.OrderBy(s => s).Select(s => s.ToString().ToLowerInvariant())
+            );
+
+            string D2Path(Type t)
+            {
+                var stage =
+                    declarations.BeforeStageSystems.Contains(t) ? "BeforeStructuralChanges"
+                    : declarations.ReactStageSystems.Contains(t) ? "ReactToStructuralChanges"
+                    : "AfterStructuralChanges";
+                return declarations.Priorities.TryGetValue(t, out var p)
+                    ? $"{stage}.priority_{p}.{t.Name}"
+                    : $"{stage}.{t.Name}";
+            }
+            d2Builder.AppendLine($"  {D2Path(pair.After)} -> {D2Path(pair.Before)}: \"{label}\"");
+        }
+
+        return d2Builder.ToString();
     }
 }

--- a/scripts/detect_cycles.py
+++ b/scripts/detect_cycles.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""检测 Graphviz DOT 格式有向图中的所有环。
+
+依赖：pydot（解析 DOT）、networkx（环检测 - Johnson 算法）
+用法：python detect_cycles <graph.dot>
+"""
+
+import sys
+from pathlib import Path
+
+import pydot
+import networkx as nx
+
+
+def parse_dot(filepath: str) -> nx.DiGraph:
+    graphs = pydot.graph_from_dot_file(filepath)
+    if not graphs:
+        raise ValueError(f"无法从 {filepath} 解析出图")
+
+    dot_graph = graphs[0]
+    if dot_graph.get_type() != "digraph":
+        raise ValueError("仅支持有向图（digraph），当前文件为无向图（graph）")
+
+    G = nx.DiGraph()
+    for edge in dot_graph.get_edges():
+        src = edge.get_source()
+        dst = edge.get_destination()
+        G.add_edge(src, dst)
+
+    return G
+
+
+def find_cycles(G: nx.DiGraph) -> list[list[str]]:
+    cycles = list(nx.simple_cycles(G))
+    return [list(cycle) for cycle in cycles]
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"用法: {sys.argv[0]} <graph.dot>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    if not Path(filepath).exists():
+        print(f"文件不存在: {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    G = parse_dot(filepath)
+
+    print(f"节点数: {G.number_of_nodes()}")
+    print(f"边数:   {G.number_of_edges()}\n")
+
+    cycles = find_cycles(G)
+
+    if not cycles:
+        print("未检测到环。该图为有向无环图（DAG）。")
+    else:
+        print(f"检测到 {len(cycles)} 个环：")
+        for i, cycle in enumerate(cycles, 1):
+            path = " -> ".join(cycle + [cycle[0]])
+            print(f"  [{i}] {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+pydot
+networkx


### PR DESCRIPTION
**新增：**

- 每条执行顺序边记录其来源类别——显式声明、优先级推断、读写属性推断或执行阶段推断，调试图表的边均标注来源，检测循环时可逐边溯源。
- 每次构建系统拓扑时自动输出两类调试图表：DOT 格式含完整边集供程序解析；D2 格式按阶段拆分容器、过滤掉跨阶段的依赖边，方便可视化。
- 配套循环依赖检测脚本，解析 DOT 输出找出全部环。

**重构：**

- 提取有向图的过程拆做两步：先提取完整原始声明，再转换为有向图。
- 直接使用数组记录排序好的系统类型，而不再专门声明冗余的 record。