### PR TITLE
feat(simulate): 将关系的记录改为响应式

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -22,6 +22,13 @@
         "dotnet-trace"
       ],
       "rollForward": false
+    },
+    "dotnet-t4": {
+      "version": "3.0.0",
+      "commands": [
+        "t4"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,1 +1,2 @@
 /Third Party/FMOD
+/Third Party/Arch

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Nine"]
 	path = Third Party/Nine
 	url = https://github.com/XCYRKDSDA/Nine.git
+[submodule "Third Party/Arch"]
+	path = Third Party/Arch
+	url = git@github.com:XCYRKDSDA/Arch.git

--- a/OpenSolarMax.Game/OpenSolarMax.Game.csproj
+++ b/OpenSolarMax.Game/OpenSolarMax.Game.csproj
@@ -34,7 +34,7 @@
     <ProjectReference Include="..\Third Party\Nine\Nine\Nine.MG.csproj" />
     <ProjectReference Include="..\Third Party\FMOD\FMOD.csproj" />
     <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj">
-      <Properties>DefineConstants=$(DefineConstants);EVENTS</Properties>
+      <AdditionalProperties>DefineConstants=$(DefineConstants);EVENTS</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 

--- a/OpenSolarMax.Game/OpenSolarMax.Game.csproj
+++ b/OpenSolarMax.Game/OpenSolarMax.Game.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arch" Version="2.1.0" />
+    <PackageReference Include="Arch" Version="2.1.0" ExcludeAssets="all" />
     <PackageReference Include="Arch.System" Version="1.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CsToml.Extensions.Configuration" Version="1.8.0" />
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Third Party\Nine\Nine\Nine.MG.csproj" />
     <ProjectReference Include="..\Third Party\FMOD\FMOD.csproj" />
+    <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenSolarMax.Game/OpenSolarMax.Game.csproj
+++ b/OpenSolarMax.Game/OpenSolarMax.Game.csproj
@@ -33,7 +33,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Third Party\Nine\Nine\Nine.MG.csproj" />
     <ProjectReference Include="..\Third Party\FMOD\FMOD.csproj" />
-    <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj" />
+    <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj">
+      <Properties>DefineConstants=$(DefineConstants);EVENTS</Properties>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenSolarMax.Launcher/OpenSolarMax.Launcher.csproj
+++ b/OpenSolarMax.Launcher/OpenSolarMax.Launcher.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+    <PackageReference Include="Arch" Version="2.1.0" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenSolarMax.Mods.Core/Concepts/Ship.cs
+++ b/OpenSolarMax.Mods.Core/Concepts/Ship.cs
@@ -102,9 +102,16 @@ public class ShipApplier(IAssetsManager assets, IConceptFactory factory) : IAppl
         // 占用一个人口
         commandBuffer.Set(in entity, new PopulationCost { Value = 1 });
 
-        // TODO 延迟化 设置所属星球
-        var (_, transformRelationship) = AnchorageUtils.AnchorShipToPlanet(entity, desc.Planet);
-        RevolutionUtils.RandomlySetShipOrbitAroundPlanet(transformRelationship, desc.PlanetOrbit);
+        var (_, transformRelationship) = AnchorageUtils.AnchorShipToPlanet(
+            commandBuffer,
+            entity,
+            desc.Planet
+        );
+        RevolutionUtils.RandomlySetShipOrbitAroundPlanet(
+            commandBuffer,
+            transformRelationship,
+            desc.PlanetOrbit
+        );
 
         // 设置所属阵营
         factory.Make(

--- a/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
+++ b/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
@@ -56,7 +56,7 @@
     <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
-      <Properties>DefineConstants=$(DefineConstants);EVENTS</Properties>
+      <AdditionalProperties>DefineConstants=$(DefineConstants);EVENTS</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 

--- a/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
+++ b/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
@@ -53,6 +53,10 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
+    <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
+++ b/OpenSolarMax.Mods.Core/OpenSolarMax.Mods.Core.csproj
@@ -56,6 +56,7 @@
     <ProjectReference Include="..\Third Party\Arch\src\Arch\Arch.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
+      <Properties>DefineConstants=$(DefineConstants);EVENTS</Properties>
     </ProjectReference>
   </ItemGroup>
 

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/DestroyBrokenRelationshipsSystem.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/DestroyBrokenRelationshipsSystem.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Reflection;
 using Arch.Buffer;
 using Arch.Core;
 using Arch.Core.Extensions;
@@ -6,42 +8,72 @@ using OpenSolarMax.Mods.Core.Components;
 
 namespace OpenSolarMax.Mods.Core.Systems;
 
-public abstract class DestroyBrokenRelationshipsSystem<TRelationship>(World world)
+/// <summary>
+/// 通过订阅参与者索引组件的移除事件自动清理损坏的关系实体，
+/// 替代每帧 Query 轮询参与者存活状态。
+/// </summary>
+public abstract class DestroyBrokenRelationshipsSystem<TRelationship>
     : ICalcSystemWithStructuralChanges
     where TRelationship : IRelationshipRecord
 {
-    private static readonly QueryDescription _relationshipDesc =
-        new QueryDescription().WithAll<TRelationship>();
+    protected DestroyBrokenRelationshipsSystem(World world)
+    {
+        foreach (var participantType in TRelationship.ParticipantTypes)
+            GetSubscriber(participantType).Invoke(world);
+    }
 
-    private static void CheckRelationship(
-        Entity relationship,
-        in TRelationship record,
-        CommandBuffer commandBuffer
+    private static void SubscribeTo<TParticipant>(World world)
+        where TParticipant : IParticipantIndex
+    {
+        world.SubscribeComponentRemoved<TParticipant>(OnParticipantIndexRemoved);
+    }
+
+    private static void OnParticipantIndexRemoved<TParticipant>(
+        in Entity entity,
+        ref TParticipant index
     )
+        where TParticipant : IParticipantIndex
     {
-        foreach (var group in record)
+        // 先快照再枚举：回调内销毁关系实体会触发索引系统的 OnRelationshipRemoved 修改同一索引
+        var relationships = index.ToArray();
+        foreach (var relationship in relationships)
         {
-            foreach (var participant in group)
-            {
-                if (!participant.IsAlive())
-                {
-                    commandBuffer.Destroy(relationship);
-                    return;
-                }
-            }
+            if (relationship.IsAlive())
+                World.Worlds[entity.WorldId].Destroy(relationship);
         }
     }
 
-    public void Update(CommandBuffer commandBuffer)
+    #region Subscriber
+
+    private static readonly MethodInfo _subscriberInfo =
+        typeof(DestroyBrokenRelationshipsSystem<TRelationship>).GetMethod(
+            nameof(SubscribeTo),
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
+
+    private delegate void SubscriberDelegate(World world);
+
+    private static readonly Dictionary<Type, SubscriberDelegate> _subscriberCache = [];
+
+    private static SubscriberDelegate GetSubscriber(Type participantType)
     {
-        foreach (var chunk in world.Query(in _relationshipDesc))
-        {
-            var recordSpan = chunk.GetSpan<TRelationship>();
-            foreach (var idx in chunk)
-                CheckRelationship(chunk.Entities[idx], recordSpan[idx], commandBuffer);
-        }
-        commandBuffer.Playback(world);
+        if (_subscriberCache.TryGetValue(participantType, out var subscriber))
+            return subscriber;
+
+        var subscriberInfo = _subscriberInfo.MakeGenericMethod(participantType);
+        subscriber = subscriberInfo.CreateDelegate<SubscriberDelegate>();
+        _subscriberCache.Add(participantType, subscriber);
+
+        return subscriber;
     }
+
+    #endregion
+
+    /// <summary>
+    /// 结构变更已由事件回调即时完成，Update 为空操作。
+    /// 系统仍保留在此以承载 ECS 拓扑上的读写声明和执行顺序约束。
+    /// </summary>
+    public void Update(CommandBuffer commandBuffer) { }
 }
 
 /// <summary>

--- a/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/IndexRelationshipSystemBase.cs
+++ b/OpenSolarMax.Mods.Core/Systems/Simulate/Relationship/IndexRelationshipSystemBase.cs
@@ -7,59 +7,74 @@ using OpenSolarMax.Mods.Core.Components;
 namespace OpenSolarMax.Mods.Core.Systems;
 
 /// <summary>
-/// 将关系实体描述的关系缓存到各个参与者的参与组件的索引中
+/// 通过 Arch 事件回调自动维护关系实体与各参与者索引组件的映射，替代每帧清空并重建。
 /// </summary>
-public abstract class IndexRelationshipSystemBase<TRelationship>(World world) : ICalcSystem
+public abstract class IndexRelationshipSystemBase<TRelationship> : ICalcSystem
     where TRelationship : IRelationshipRecord
 {
-    private readonly QueryDescription _relationshipDesc =
-        new QueryDescription().WithAll<TRelationship>();
-
-    protected static void ClearAllIndex<TParticipant>(World world)
-        where TParticipant : IParticipantIndex =>
-        world.Query(
-            new QueryDescription().WithAll<TParticipant>(),
-            (Entity _, ref TParticipant index) => index.Clear()
-        );
-
-    #region `ClearAllIndex` Cache
-
-    private static readonly MethodInfo _clearerInfo =
-        typeof(IndexRelationshipSystemBase<TRelationship>).GetMethod(
-            "ClearAllIndex",
-            BindingFlags.Static | BindingFlags.NonPublic
-        )!;
-
-    private delegate void ClearerDelegate(World world);
-
-    private static readonly Dictionary<Type, ClearerDelegate> _clearerCache = [];
-
-    private static ClearerDelegate GetClearer(Type indexType)
+    protected IndexRelationshipSystemBase(World world)
     {
-        if (_clearerCache.TryGetValue(indexType, out var clearer))
-            return clearer;
-
-        var clearerInfo = _clearerInfo.MakeGenericMethod(indexType);
-        clearer = clearerInfo.CreateDelegate<ClearerDelegate>();
-        _clearerCache.Add(indexType, clearer);
-
-        return clearer;
+        world.SubscribeComponentAdded<TRelationship>(OnRelationshipAdded);
+        world.SubscribeComponentSet<TRelationship>(OnRelationshipSet);
+        world.SubscribeComponentRemoved<TRelationship>(OnRelationshipRemoved);
     }
 
-    #endregion
+    private static void OnRelationshipAdded(in Entity entity, ref TRelationship record)
+    {
+        foreach (var group in (ILookup<Type, Entity>)record)
+        {
+            var indexer = GetIndexer(group.Key);
+            foreach (var participant in group)
+            {
+                if (participant.IsAlive())
+                    indexer.Invoke(entity, participant);
+            }
+        }
+    }
 
-    protected static void BuildIndex<TParticipant>(Entity relationship, Entity participant)
+    private static void OnRelationshipSet(
+        in Entity entity,
+        in TRelationship oldValue,
+        ref TRelationship newValue
+    )
+    {
+        foreach (var group in (ILookup<Type, Entity>)oldValue)
+        {
+            var remover = GetRemover(group.Key);
+            foreach (var participant in group)
+            {
+                if (participant.IsAlive())
+                    remover.Invoke(entity, participant);
+            }
+        }
+        OnRelationshipAdded(entity, ref newValue);
+    }
+
+    private static void OnRelationshipRemoved(in Entity entity, ref TRelationship record)
+    {
+        foreach (var group in (ILookup<Type, Entity>)record)
+        {
+            var remover = GetRemover(group.Key);
+            foreach (var participant in group)
+            {
+                if (participant.IsAlive())
+                    remover.Invoke(entity, participant);
+            }
+        }
+    }
+
+    #region Indexer
+
+    private static void BuildIndex<TParticipant>(Entity relationship, Entity participant)
         where TParticipant : IParticipantIndex
     {
         if (participant.Has<TParticipant>())
             participant.Get<TParticipant>().Add(relationship);
     }
 
-    #region `BuildIndex` Cache
-
     private static readonly MethodInfo _indexerInfo =
         typeof(IndexRelationshipSystemBase<TRelationship>).GetMethod(
-            "BuildIndex",
+            nameof(BuildIndex),
             BindingFlags.Static | BindingFlags.NonPublic
         )!;
 
@@ -81,32 +96,42 @@ public abstract class IndexRelationshipSystemBase<TRelationship>(World world) : 
 
     #endregion
 
-    protected virtual void BuildIndex(Entity relationship, in TRelationship record)
+    #region Remover
+
+    private static void RemoveFromIndex<TParticipant>(Entity relationship, Entity participant)
+        where TParticipant : IParticipantIndex
     {
-        foreach (var group in record)
-        {
-            var indexer = GetIndexer(group.Key);
-            foreach (var participant in group)
-            {
-                if (participant.IsAlive())
-                    indexer.Invoke(relationship, participant);
-            }
-        }
+        if (participant.Has<TParticipant>())
+            participant.Get<TParticipant>().Remove(relationship);
     }
 
-    public void Update()
-    {
-        // 清空所有索引
-        foreach (var participantType in TRelationship.ParticipantTypes)
-            GetClearer(participantType).Invoke(world);
+    private static readonly MethodInfo _removerInfo =
+        typeof(IndexRelationshipSystemBase<TRelationship>).GetMethod(
+            nameof(RemoveFromIndex),
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
 
-        // 遍历关系记录，重新构建索引
-        var query = world.Query(in _relationshipDesc);
-        foreach (var chunk in query.GetChunkIterator())
-        {
-            var recordSpan = chunk.GetSpan<TRelationship>();
-            foreach (var idx in chunk)
-                BuildIndex(chunk.Entities[idx], in recordSpan[idx]);
-        }
+    private delegate void RemoverDelegate(Entity relationship, Entity participant);
+
+    private static readonly Dictionary<Type, RemoverDelegate> _removerCache = [];
+
+    private static RemoverDelegate GetRemover(Type indexType)
+    {
+        if (_removerCache.TryGetValue(indexType, out var remover))
+            return remover;
+
+        var removerInfo = _removerInfo.MakeGenericMethod(indexType);
+        remover = removerInfo.CreateDelegate<RemoverDelegate>();
+        _removerCache.Add(indexType, remover);
+
+        return remover;
     }
+
+    #endregion
+
+    /// <summary>
+    /// 索引已由事件回调增量维护，Update 为空操作。
+    /// 系统仍保留在此以承载 ECS 拓扑上的读写声明（[ReadCurr]/[Write] 等）和执行顺序约束。
+    /// </summary>
+    public void Update() { }
 }

--- a/OpenSolarMax.Mods.Core/Utils/AnchorageUtils.cs
+++ b/OpenSolarMax.Mods.Core/Utils/AnchorageUtils.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Arch.Buffer;
 using Arch.Core;
 using Arch.Core.Extensions;
 using OpenSolarMax.Mods.Core.Components;
@@ -8,24 +9,26 @@ namespace OpenSolarMax.Mods.Core.Utils;
 
 public static class AnchorageUtils
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static (Entity AnchorageRelationship, Entity TransformRelationship) AnchorShipToPlanet(
+        CommandBuffer commandBuffer,
         Entity ship,
         Entity planet
     )
     {
         Debug.Assert(ship.WorldId == planet.WorldId);
-        var world = World.Worlds[ship.WorldId];
 
-        // 设置停靠关系
-        var anchorageRelationship = world.Create(new TreeRelationship<Anchorage>(planet, ship));
+        var anchorageRelationship = commandBuffer.Create([typeof(TreeRelationship<Anchorage>)]);
+        commandBuffer.Set(in anchorageRelationship, new TreeRelationship<Anchorage>(planet, ship));
 
-        // 设置变换关系
-        var transformRelationship = world.Create(
-            new TreeRelationship<RelativeTransform>(planet, ship),
-            new RelativeTransform(),
-            new RevolutionOrbit(),
-            new RevolutionState()
+        var transformRelationship = commandBuffer.Create([
+            typeof(TreeRelationship<RelativeTransform>),
+            typeof(RelativeTransform),
+            typeof(RevolutionOrbit),
+            typeof(RevolutionState),
+        ]);
+        commandBuffer.Set(
+            in transformRelationship,
+            new TreeRelationship<RelativeTransform>(planet, ship)
         );
 
         return (anchorageRelationship, transformRelationship);

--- a/OpenSolarMax.Mods.Core/Utils/RevolutionUtils.cs
+++ b/OpenSolarMax.Mods.Core/Utils/RevolutionUtils.cs
@@ -1,5 +1,5 @@
+using Arch.Buffer;
 using Arch.Core;
-using Arch.Core.Extensions;
 using Microsoft.Xna.Framework;
 using OpenSolarMax.Mods.Core.Components;
 
@@ -46,6 +46,7 @@ public static class RevolutionUtils
     private const float _defaultOrbitOffsetRange = 0.3f;
 
     public static void RandomlySetShipOrbitAroundPlanet(
+        CommandBuffer commandBuffer,
         Entity relationship,
         in PlanetGeostationaryOrbit planetOrbit,
         Random? random = null,
@@ -54,12 +55,11 @@ public static class RevolutionUtils
     {
         random ??= new();
 
-        relationship.Get<RevolutionOrbit>() = CreateRandomRevolutionOrbit(
-            in planetOrbit,
-            random,
-            orbitOffsetRange
+        commandBuffer.Set(
+            in relationship,
+            CreateRandomRevolutionOrbit(in planetOrbit, random, orbitOffsetRange)
         );
-        relationship.Get<RevolutionState>() = CreateRandomState(random);
+        commandBuffer.Set(in relationship, CreateRandomState(random));
     }
 
     /// <summary>

--- a/OpenSolarMax.slnx
+++ b/OpenSolarMax.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Third Party/">
     <Project Path="Third Party/FMOD/FMOD.csproj" />
     <Project Path="Third Party/Nine/Nine/Nine.MG.csproj" />
+    <Project Path="Third Party/Arch/src/Arch/Arch.csproj" />
   </Folder>
   <Project Path="OpenSolarMax.Game/OpenSolarMax.Game.csproj" />
   <Project Path="OpenSolarMax.Launcher/OpenSolarMax.Launcher.csproj" />


### PR DESCRIPTION
**新增：**

- 将 Arch 依赖从 NuGet 包替换为 fork 仓库子模块，并启用 Arch 的 EVENTS 宏。
- 升级 Arch 版本，使 Set 事件提供组件的旧值，且 `CommandBuffer` 对操作进行压缩，并优先执行 Destroy/Remove 后执行 Create/Add/Set。
- 将关系的记录和清理改为响应式。索引不再每帧清空重建，改为在关系组件被添加、修改、移除时通过 Arch 事件回调增量更新，索引始终与关系状态一致。

**修复：**

- 将飞船停靠和设置随机公转轨道改为延迟生效。生成飞船时不再立即创建停靠关系和公转轨道，而是放入 `CommandBuffer`，统一到结构变更阶段生效。